### PR TITLE
Add strupr implementation for non non-MS toolchain builds

### DIFF
--- a/tools/bin2txt/bin2txt.c
+++ b/tools/bin2txt/bin2txt.c
@@ -49,6 +49,19 @@ void PrintOptions(char *str)
 	
 } //end of PrintOptions()
 
+#ifndef HAVE_STRUPR
+char* strupr(char* s)
+{
+	char* tmp = s;
+
+	for (;*tmp;++tmp) {
+		*tmp = toupper((unsigned char) *tmp);
+	}
+
+	return s;
+}
+#endif
+
 /// M A I N ////////////////////////////////////////////////////////////
 
 #include <math.h>


### PR DESCRIPTION
Trying to build everything on Linux, this will help if we could remove the `strupr` usage (or use this implementation)

`strupr` is non-standard functions from Microsoft's C library.

Haven't try my changes on Windows, if you can do it??