### PR TITLE
DynamicSprite sample bugfix: For an unknown reason padkeya value is not equal to 0.

### DIFF
--- a/snes-examples/graphics/Sprites/DynamicSprite/DynamicSprite.c
+++ b/snes-examples/graphics/Sprites/DynamicSprite/DynamicSprite.c
@@ -82,6 +82,8 @@ int main(void) {
 
 	// add new sprite to queue
 	addSprite(&gfxpsrite, ADRGFXSPR);
+
+	padkeya=0;
 	
 	// Wait for nothing :P
 	while(1) {


### PR DESCRIPTION
1) Bug Description
When A is pressed in DynamicSprite sample, the sprite is not updated.

2) Solution
For an unknown reason `padkeya` value is not equal to 0 even if it is set in the while loop:
```
			if(pad0 & KEY_A) {
				// if not yet pressed
				if (padkeya == 0) {
					padkeya=1;  // avoid adding new sprite continuisly
					// add new sprite to queue
					addSprite((&gfxpsrite)+8*4*2, ADRGFXSPR);
				}
				
			}
			else
				padkeya=0;
```
Initializing `padkeya` to 0 before the while loop solves this issue.