### PR TITLE
Better handling of missing strupr for bin2txt under linux

### DIFF
--- a/tools/bin2txt/Makefile
+++ b/tools/bin2txt/Makefile
@@ -14,6 +14,7 @@ LIBS=
 
 ifeq ($(OS),Windows_NT)
 	EXT=.exe
+	CFLAGS += -D__HAS_STRUPR
 else
 	EXT=
 endif

--- a/tools/bin2txt/bin2txt.c
+++ b/tools/bin2txt/bin2txt.c
@@ -42,7 +42,7 @@ char filename[256];			// output filename
 
 //// F U N C T I O N S //////////////////////////////////////////////////////////
 
-#ifndef __CYGWIN__
+#ifndef __HAS_STRUPR
 void strupr(char *str)
 {
 	while(*str)


### PR DESCRIPTION
Fix bin2txt compilation problem with MINGW