### PR TITLE
Correct extra qualification on member error

### DIFF
--- a/tools/smconv/it2spc.h
+++ b/tools/smconv/it2spc.h
@@ -127,8 +127,8 @@ namespace IT2SPC {
 		std::vector<Sample*> Samples;
 		
 
-		void Module::ParseSMOption( const char * );
-		void Module::ParseSMOptions( const ITLoader::Module & );
+		void ParseSMOption( const char * );
+		void ParseSMOptions( const ITLoader::Module & );
 		
 	public:
 		Module( 


### PR DESCRIPTION
This error is caused by the program originating from Visual Studio, which
sometimes supports things standard compliant compilers don't support.

This merge request closes #79.