### PR TITLE
wla update

### DIFF
--- a/devkitsnes/snes_rules
+++ b/devkitsnes/snes_rules
@@ -78,7 +78,9 @@ export OFILES	:=	$(BINFILES:.bin=.obj) $(CFILES:.c=.obj) $(SFILES:.asm=.obj)
 %.obj: %.asm
 	@echo Doing obj files ... $(fname)
 	@echo "Building with -x flag: $(AS) -s -x -o $@ $<"
-	$(AS) -s -x -o $@ $< 
+# -d switch disable WLA's ability to calculate A-B where A and B are labels.
+# if you remove it, you will have some updates to do at least in crt0_snes.asm
+	$(AS) -d -s -x -o $@ $< 
 
 #---------------------------------------------------------------------------------
 %.asm: %.ps

--- a/pvsneslib/source/crt0_snes.asm
+++ b/pvsneslib/source/crt0_snes.asm
@@ -31,6 +31,9 @@ tcc__registers_irq dsb 0
 tcc__regs_irq dsb 48
 .ENDS
 
+; sections "globram.data" and "glob.data" can stay here in the file
+; because we are using wla-65816 -d switch to disable WLA's ability to calculate A-B where A and B are labels.
+; If you remove the -d switch, move those two sections to the very end of the source file, then WLA cannot calculate SECTIONEND_glob.data-SECTIONSTART_glob.data and it should be delayed for WLALINK to calculate
 .RAMSECTION "globram.data" BANK $7f SLOT 3 KEEP
 
 .ENDS

--- a/pvsneslib/source/videos.asm
+++ b/pvsneslib/source/videos.asm
@@ -79,6 +79,10 @@ videoModeSub        DSB 1
 bgCnt               DSB 1
 iloc                DSB 1
 
+.ENDS
+
+.RAMSECTION ".reg_video7e_matrix" BANK $7E 
+
 m7ma                DSB 2
 m7mb                DSB 2
 m7mc                DSB 2

--- a/readme.md
+++ b/readme.md
@@ -20,10 +20,10 @@ Due to technical constraints, it is available for now on 32 bits system only.
 
 To use it, you will need at least :
 
-- a unix-like environment like msys
-- python 3
+- a unix-like environment like msys if you work on Windows
+- python 3 installed and available in your path environment variable (accessible with the **python** command)
 
-If you want to compile the whole project, please see the wiki pages to get all required dependencies.
+If you want to compile the whole project, please see [this wiki page](https://github.com/alekmaul/pvsneslib/wiki/Compiling-from-sources) to get all required dependencies.
 
 # Contribution #
 
@@ -33,6 +33,6 @@ To discuss about the library, your project or to request help, join us on [Disco
 
 PVSneslib and affiliated tools are distributed under the MIT license (see pvsneslib_license.txt file).
 
-If you want to donate to support PVSneslib development:  
-[![Paypal](https://www.paypalobjects.com/fr_FR/FR/i/btn/x-click-but04.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=Y5USKF23DQVLC)
+If you want to donate to support PVSneslib development:  [![Paypal](https://www.paypalobjects.com/fr_FR/FR/i/btn/x-click-but04.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=Y5USKF23DQVLC)
+
 Thanks !


### PR DESCRIPTION
- Update to the last version of wla which now contains the -d flag to disable WLA's ability to calculate A-B where A and B are labels. Will fix bugs with the "breakout" sample
- Added more details in the description of the home page
- moved m7* variables to a specific ramsection to avoid see it everywhere (point discussed with Alekmaul). The 2 examples of mode 7 still works like before, no impact seen !