### PR TITLE
Add package to fedora container to build on develop branch, update do…

### DIFF
--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -49,8 +49,16 @@ usage: ./dockerrun.sh options:<d|h|c>
 
 ```
 * -d: specify the distribution (mandatory). Fedora, debian and ubuntu are availables (latest version).
+```
+  ./dockerrun -d fedora
+```
 
 * -r: create a zip file (release) for the current build (so fedora, ubuntu or debian). By default it uses `/var/tmp/build/` as destination, but you can provide a custom path who'll be created.
+```
+  ./dockerrun -d fedora -r # zip release will be stored in /var/tmp/build
+# or by providing a custom path
+  ./dockerrun -d fedora -r /somewhere/over/the/rainbow # zip release will be stored in /somewhere/over/the/rainbow
+```
 
 * -b: Remove progression bar, useful in batch mode (no terminal) to avoid dirty output.
 

--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -36,10 +36,10 @@ Add your current user to the docker group and restart your system to make it eff
   sudo usermod -aG docker <username>
 ```
 
-Then, execute the dockerrrun.sh script. Four options are availables
+Then, execute the dockerrun.sh script. Four options are availables
 * -h: see help
 ```
-  ./dockerrrun -h
+  ./dockerrun -h
 
 usage: ./dockerrun.sh options:<d|h|c>
 -d: name of the linux distrubtion (fedora, ubuntu or debian)
@@ -48,46 +48,11 @@ usage: ./dockerrun.sh options:<d|h|c>
 -b: Run this script in batch mode, useful when using without terminal
 
 ```
-* -d: specify the distribution (mandatory). Fedora, debian and ubuntu are availables (latest version)
-```
-  ./dockerrrun -d fedora
+* -d: specify the distribution (mandatory). Fedora, debian and ubuntu are availables (latest version).
 
->> [DOCKER] Building image pvsneslib-fedora-image [PASS]
+* -r: create a zip file (release) for the current build (so fedora, ubuntu or debian). By default it uses `/var/tmp/build/` as destination, but you can provide a custom path who'll be created.
 
->> [DOCKER] Running container pvsneslib-fedora-image...
-
-        >> [MAKE]   Cleaning files                   [PASS]
-
-        >> [GIT]    Refreshing source code           [PASS]
-
-        >> [MAKE]   Compiling code and installing it [PASS]
-
-```
-* -r: create a zip file (release) for the current build (so fedora, ubuntu or debian). Must be used with `-d <distribution>`. Here an output with ubuntu container:
-```
-    ./dockerrrun -d fedora -r
-
->> [DOCKER] Building image pvsneslib-ubuntu-image [PASS]
-
->> [DOCKER] Running container pvsneslib-ubuntu-image...
-
-        >> [MAKE]   Cleaning files                   [PASS]
-
-        >> [GIT]    Refreshing source code           [PASS]
-
-        >> [MAKE]   Compiling code and installing it [PASS]
-
-
->> [ZIP] Building release for pvsneslib-ubuntu-image [PASS]
-
-The release is /var/tmp/build/pvsneslib-ubuntu-image.zip
-```
-You can ever build all distrutions et create release (zip) files on the fly as follows
-```bash
-$ for d in fedora debian ubuntu; do
-    ./dockerrun.sh -d $d -r
-done
-```
+* -b: Remove progression bar, useful in batch mode (no terminal) to avoid dirty output.
 
 This script doesn't print any output from the executed tasks.
 Each tasks are stored in a dedicated logfile in `docker/<distribution>/`

--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -1,43 +1,71 @@
-
 # Build code from docker container
 
+This readme explains how and why to use docker containers.
+
 - [Build code from docker container](#build-code-from-docker-container)
+  - [Why use docker for this project](#why-use-docker-for-this-project)
   - [Features](#features)
+  - [Integrated linux distributions](#integrated-linux-distributions)
   - [Installation](#installation)
+  - [How to use dockerrun.sh](#how-to-use-dockerrunsh)
+    - [Use cases](#use-cases)
+  - [Remarks](#remarks)
   - [Todo](#todo)
+  - [To contribute](#to-contribute)
 
-This page explains how to build your code via a linux container.
+## Why use docker for this project
 
+- Each distribution uses different package versions, by testing the most used distributions, it is easier to trace the regressions between each release of **pvsneslib**.
+- You don't want to install all the development packages on your OS but you want to be able to compile the code and test by yourself.
+- The Dockerfiles serve as documentation if you want to test the compilation locally on your distribution but you don't know which packages to install.
+- Have the possibility to add continuous integration by testing the modifications with each modification
+- Have the possibility to push each new version of pvsneslib in github in the release section
+- And so on...
 
 ## Features
 
-- Build code from fedora, debian and ubuntu containers
-- Create release (zip file) in /var/tmp/build
+- Compile **pvnseslib** tools from different linux distribution versions.
+- Create ready-to-use releases in zip form
+- Check that pvsneslib compiles correctly on different linux distributions, and thus test different versions of tools and libraries used to compile.
 
+## Integrated linux distributions
+
+- ![Cent OS](https://img.shields.io/badge/cent%20os-002260?style=for-the-badge&logo=centos&logoColor=F0F0F0)
+- ![Debian](https://img.shields.io/badge/Debian-D70A53?style=for-the-badge&logo=debian&logoColor=white)
+- ![Fedora](https://img.shields.io/badge/Fedora-294172?style=for-the-badge&logo=fedora&logoColor=white)
+- ![Ubuntu](https://img.shields.io/badge/Ubuntu-E95420?style=for-the-badge&logo=ubuntu&logoColor=white)
+
+All these distributions are in latest stable version.
 
 ## Installation
 
-Install docker-ce according to your distribution
+As a prerequisite, you must install docker-ce on your distribution.
 
+* [centos](https://docs.docker.com/engine/install/centos/)
 * [fedora](https://docs.docker.com/engine/install/fedora/)
 * [debian](https://docs.docker.com/engine/install/debian/)
 * [ubuntu](https://docs.docker.com/engine/install/ubuntu/)
-* [centos](https://docs.docker.com/engine/install/centos/)
+
+These distributions have been integrated because they represent the most used ones (not exhaustive). [See Top Linux Subcategories by market share](https://truelist.co/blog/linux-statistics/).
 
 
-Activate and start the docker service
+Activate and start the docker service.
 ```
  sudo systemctl enable docker
  sudo systemctl start docker
 ```
 
-Add your current user to the docker group and restart your system to make it effective
+Add your current user to the docker group and restart your system to make it effective.
 ```
   sudo usermod -aG docker <username>
 ```
 
-Then, execute the dockerrun.sh script. Four options are availables
-* -h: see help
+## How to use dockerrun.sh
+
+Above all, this script must be executed at the root of the project, which is the equivalent of `PVSNESLIB_HOME`.
+
+No need to set this environment variable, the script takes care of it for you.
+
 ```
   ./dockerrun -h
 
@@ -48,25 +76,52 @@ usage: ./dockerrun.sh options:<d|h|c>
 -b: Run this script in batch mode, useful when using without terminal
 
 ```
-* -d: specify the distribution (mandatory). Fedora, debian and ubuntu are availables (latest version).
+
+### Use cases
+
+I just want to compile my code for my ubuntu distribution.
+
 ```
-  ./dockerrun -d fedora
+  ./dockerrun -d ubuntu
+
+```
+> Notes: The `-d` option is the only mandatory option (except help `-h` menu).
+
+I want to compile my code for my **ubuntu** distribution and create my own release (zip).
+
+```
+  ./dockerrun -d ubuntu -r
+
 ```
 
-* -r: create a zip file (release) for the current build (so fedora, ubuntu or debian). By default it uses `/var/tmp/build/` as destination, but you can provide a custom path who'll be created.
+In this case, the archive will be located in `/var/tmp`.
+
+Ditto but I want to put my archive in a custom directory.
+
 ```
-  ./dockerrun -d fedora -r # zip release will be stored in /var/tmp/build
-# or by providing a custom path
-  ./dockerrun -d fedora -r /somewhere/over/the/rainbow # zip release will be stored in /somewhere/over/the/rainbow
+  ./dockerrun -d ubuntu -r /somewhere/over/the/rainbow
+
 ```
 
-* -b: Remove progression bar, useful in batch mode (no terminal) to avoid dirty output.
+Finally I want to integrate this script in batch mode (without terminal), without progress bars to keep readable logs.
 
-This script doesn't print any output from the executed tasks.
-Each tasks are stored in a dedicated logfile in `docker/<distribution>/`
+```
+  ./dockerrun -d ubuntu -b
+
+```
+
+## Remarks
+
+The **centos** and **fedora** versions (especially) take longer on first use (to build the docker image). Made some changes to improve build times.
+
 
 ## Todo
 
-- Add tag version when creating the release (zip)
-- Add CI: launch build and tests on each PR to be validated
-- Add CD: push release on github when all steps are successful
+- Add the ability to specify a **git tag** and build a release from it.
+- Add continuous integration to pre-validate each pull request.
+  - In addition to validating the correct compilation of the code, we could add a checksum test on the sfc files in the examples, comparing them to those of the latest versions. If the hash does not change, everything is fine, otherwise raise a warning and test the rom manually. This avoids systematically testing each rom following a new version of **pvsneslib**.
+- Add continuous delivery by creating pushing a new release in **github** automatically.
+
+## To contribute
+
+Do not hesitate to give your feedback, suggest changes or simply bring some yourself.

--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -1,6 +1,10 @@
 
 # Build code from docker container
 
+- [Build code from docker container](#build-code-from-docker-container)
+  - [Features](#features)
+  - [Installation](#installation)
+  - [Todo](#todo)
 
 This page explains how to build your code via a linux container.
 
@@ -13,39 +17,39 @@ This page explains how to build your code via a linux container.
 
 ## Installation
 
-Install docker on your linux system
+Install docker-ce according to your distribution
 
-Here an exemple for fedora systems
-```bash
-  sudo dnf -y install docker
-  sudo systemctl enable docker.service
-  sudo systemctl start docker.service
+* [fedora](https://docs.docker.com/engine/install/fedora/)
+* [debian](https://docs.docker.com/engine/install/debian/)
+* [ubuntu](https://docs.docker.com/engine/install/ubuntu/)
+* [centos](https://docs.docker.com/engine/install/centos/)
+
+
+Activate and start the docker service
+```
+ sudo systemctl enable docker
+ sudo systemctl start docker
 ```
 
 Add your current user to the docker group and restart your system to make it effective
-```bash
+```
   sudo usermod -aG docker <username>
 ```
-## Usage/Examples
 
-Clone the pvsneslib repository and move to the root of the project (pvsneslib)
-```bash
-  git clone https://github.com/alekmaul/pvsneslib.git
-  cd pvsneslib
-```
-
-Then, execute the dockerrrun.sh script. Three options are availables
+Then, execute the dockerrrun.sh script. Four options are availables
 * -h: see help
-```bash
+```
   ./dockerrrun -h
 
 usage: ./dockerrun.sh options:<d|h|c>
 -d: name of the linux distrubtion (fedora, ubuntu or debian)
 -h: help, print this message
--r: Create release (zip) to /var/tmp/build
+-r: Create release (zip) to /var/tmp/build by default or by providing a custon path in parameter
+-b: Run this script in batch mode, useful when using without terminal
+
 ```
 * -d: specify the distribution (mandatory). Fedora, debian and ubuntu are availables (latest version)
-```bash
+```
   ./dockerrrun -d fedora
 
 >> [DOCKER] Building image pvsneslib-fedora-image [PASS]
@@ -60,7 +64,7 @@ usage: ./dockerrun.sh options:<d|h|c>
 
 ```
 * -r: create a zip file (release) for the current build (so fedora, ubuntu or debian). Must be used with `-d <distribution>`. Here an output with ubuntu container:
-```bash
+```
     ./dockerrrun -d fedora -r
 
 >> [DOCKER] Building image pvsneslib-ubuntu-image [PASS]
@@ -86,19 +90,9 @@ done
 ```
 
 This script doesn't print any output from the executed tasks.
-Each tasks are stored as logfile in `docker/<distribution>/`, in this order:
+Each tasks are stored in a dedicated logfile in `docker/<distribution>/`
 
-1. docker_build.log: output of `docker build ...`
-2. make_clean.log: output of `make Cleaning`
-3. git_refresh.log: output of `git submodule update --init`
-4. make.log: output of `make` and `make install`
-
-Additionnaly, the `infos.log` provides useful information about the system and the container used (os, kernel, docker and gcc version).
-
-If you use `vscode` as editor, I suggest you to install the `AutoScroll` extension (from Pejman Nikram) to be able to read log in real time from your editor. By default, this extension is configured on **ON** for logfiles.
-
-
-## TODO
+## Todo
 
 - Add tag version when creating the release (zip)
 - Add CI: launch build and tests on each PR to be validated

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM centos:latest
 LABEL maintainer="kobenairb <kobenairb@gmail.com>"
 
 ENV TERM xterm
@@ -8,21 +8,25 @@ ENV DISTRO $DISTRO
 
 RUN echo 'PS1=$PS1A' >> ~/.bashrc
 
+RUN sed -i 's/mirrorlist/#mirrorlist/g' \
+        /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' \
+        /etc/yum.repos.d/CentOS-*
+
 RUN echo "minrate=30k" >> /etc/dnf/dnf.conf
 
 RUN echo "max_parallel_downloads=10" >> /etc/dnf/dnf.conf
 
-RUN sed -i 's|enabled=1|enabled=0|g' /etc/yum.repos.d/fedora-cisco-openh264.repo
-
-RUN sed -i 's|enabled=1|enabled=0|g' /etc/yum.repos.d/fedora-modular.repo
-
 RUN dnf -y upgrade && \
     dnf -y groupinstall "Development Tools" && \
+    dnf -y install dnf-plugins-core && \
+    dnf -y config-manager --set-enabled powertools && \
     dnf -y install glibc-devel.i686 \
         cmake\
         gcc-c++ \
-        python \
+        python3 \
         glibc-static \
-        libstdc++-static
+        libstdc++-static && \
+    alternatives --set python /usr/bin/python3
 
 CMD ./docker/scripts/container.sh "${PVSNESLIB_HOME}" "${DISTRO}"

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -10,24 +10,12 @@ RUN echo 'PS1=$PS1A' >> ~/.bashrc
 
 RUN apt-get update -y && \
     dpkg --add-architecture i386 && \
-    apt-get install build-essential gcc-multilib git python-is-python3 cmake wget -y
+    apt-get install -y build-essential \
+        gcc-multilib \
+        git \
+        python-is-python3 \
+        cmake \
+        wget
 
-CMD /bin/echo -e "\n>>>>> CONTAINER INFORMATIONS" >> ${PVSNESLIB_HOME}/docker/${DISTRO}/infos.log && \
-    /bin/echo -n "O.S version " >> ${PVSNESLIB_HOME}/docker/${DISTRO}/infos.log && \
-    egrep '^PRETTY_NAME' /etc/os-release | \
-        cut -d "=" -f2 |\
-        sed 's/"//g' >> ${PVSNESLIB_HOME}/docker/${DISTRO}/infos.log && \
-    /bin/echo -n "Kernel version " >> ${PVSNESLIB_HOME}/docker/${DISTRO}/infos.log && \
-    uname -a >> ${PVSNESLIB_HOME}/docker/${DISTRO}/infos.log && \
-    /bin/echo "gcc version:" >> ${PVSNESLIB_HOME}/docker/${DISTRO}/infos.log && \
-    gcc -v 2>> ${PVSNESLIB_HOME}/docker/${DISTRO}/infos.log && \
-    /bin/echo -ne "\n\t>> [MAKE]   Cleaning files                   " && \
-    make clean > ${PVSNESLIB_HOME}/docker/${DISTRO}/make_clean.log 2>&1 && \
-    /bin/echo -e "[PASS]\n" || { echo -e "[FAILED]\n"; exit 1; } && \
-    /bin/echo -ne "\t>> [GIT]    Refreshing source code           " && \
-    git submodule update --init > ${PVSNESLIB_HOME}/docker/${DISTRO}/git_refresh.log 2>&1 && \
-    /bin/echo -e "[PASS]\n" || { echo -e "[FAILED]\n"; exit 1; } && \
-    /bin/echo -ne "\t>> [MAKE]   Compiling code and installing it " && \
-    make > ${PVSNESLIB_HOME}/docker/${DISTRO}/make.log 2>&1 && \
-    /bin/echo -e "[PASS]\n" || { echo -e "[FAILED]\n"; exit 1; }
+CMD ./docker/scripts/container.sh "${PVSNESLIB_HOME}" "${DISTRO}"
 

--- a/docker/fedora/Dockerfile
+++ b/docker/fedora/Dockerfile
@@ -8,29 +8,13 @@ ENV DISTRO $DISTRO
 
 RUN echo 'PS1=$PS1A' >> ~/.bashrc
 
-RUN echo "minrate=30k" >> /etc/dnf/dnf.conf
-RUN echo "max_parallel_downloads=10" >> /etc/dnf/dnf.conf
-RUN echo "fastestmirror=True" >> /etc/dnf/dnf.conf
-
 RUN dnf upgrade --refresh -y && \
     dnf -y groupinstall "Development Tools" && \
-    dnf -y install glibc-devel.i686 cmake gcc-c++ python
+    dnf -y install glibc-devel.i686 \
+        cmake\
+        gcc-c++ \
+        python \
+        glibc-static \
+        libstdc++-static
 
-CMD echo -e "\n>>>>> CONTAINER INFORMATIONS" >> ${PVSNESLIB_HOME}/docker/${DISTRO}/infos.log && \
-    echo -n "O.S version " >> ${PVSNESLIB_HOME}/docker/${DISTRO}/infos.log && \
-    egrep '^PRETTY_NAME' /etc/os-release | \
-        cut -d "=" -f2 |\
-        sed 's/"//g' >> ${PVSNESLIB_HOME}/docker/${DISTRO}/infos.log && \
-    echo -n "Kernel version " >> ${PVSNESLIB_HOME}/docker/${DISTRO}/infos.log && \
-    uname -a >> ${PVSNESLIB_HOME}/docker/${DISTRO}/infos.log && \
-    echo "gcc version:" >> ${PVSNESLIB_HOME}/docker/${DISTRO}/infos.log && \
-    gcc -v 2>> ${PVSNESLIB_HOME}/docker/${DISTRO}/infos.log && \
-    echo -ne "\n\t>> [MAKE]   Cleaning files                   " && \
-    make clean > ${PVSNESLIB_HOME}/docker/${DISTRO}/make_clean.log 2>&1 && \
-    echo -e "[PASS]\n" || { echo -e "[FAILED]\n"; exit 1; } && \
-    echo -ne "\t>> [GIT]    Refreshing source code           " && \
-    git submodule update --init > ${PVSNESLIB_HOME}/docker/${DISTRO}/git_refresh.log 2>&1 && \
-    echo -e "[PASS]\n" || { echo -e "[FAILED]\n"; exit 1; } && \
-    echo -ne "\t>> [MAKE]   Compiling code and installing it " && \
-    make > ${PVSNESLIB_HOME}/docker/${DISTRO}/make.log 2>&1 && \
-    echo -e "[PASS]\n" || { echo -e "[FAILED]\n"; exit 1; }
+CMD ./docker/scripts/container.sh "${PVSNESLIB_HOME}" "${DISTRO}"

--- a/docker/scripts/container.sh
+++ b/docker/scripts/container.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+source "./docker/scripts/include/libraries.sh"
+
+PVSNESLIB_HOME="${1}"
+DISTRO="${2}"
+padding_width=35
+
+export padding_width
+
+git fetch --all >"${PVSNESLIB_HOME}/docker/${DISTRO}/git_fetch_all.log" 2>&1
+f_print_message "GIT" "Feching all" $?
+
+git submodule update --init >"${PVSNESLIB_HOME}/docker/${DISTRO}/git_update_submodule.log" 2>&1
+f_print_message "GIT" "Updating submodules" $?
+
+make clean >"${PVSNESLIB_HOME}/docker/${DISTRO}/make_clean.log" 2>&1
+f_print_message "MAKE" "Cleaning" $?
+
+make >"${PVSNESLIB_HOME}/docker/${DISTRO}/make.log" 2>&1
+f_print_message "MAKE" "Compiling and installing" $?

--- a/docker/scripts/container.sh
+++ b/docker/scripts/container.sh
@@ -9,10 +9,10 @@ padding_width=35
 export padding_width
 
 git fetch --all >"${PVSNESLIB_HOME}/docker/${DISTRO}/git_fetch_all.log" 2>&1
-f_print_message "GIT" "Feching all" $?
+f_print_message "GIT" "Fechting all" $?
 
 git submodule update --init >"${PVSNESLIB_HOME}/docker/${DISTRO}/git_update_submodule.log" 2>&1
-f_print_message "GIT" "Updating submodules" $?
+f_print_message "GIT" "Updating submodule(s)" $?
 
 make clean >"${PVSNESLIB_HOME}/docker/${DISTRO}/make_clean.log" 2>&1
 f_print_message "MAKE" "Cleaning" $?

--- a/docker/scripts/include/libraries.sh
+++ b/docker/scripts/include/libraries.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+
+# shellcheck disable=SC2154
+
+function f_usage {
+
+    echo "usage: ${0} options:<d|h|c>"
+    echo "-d: name of the linux distrubtion (fedora, ubuntu or debian)"
+    echo "-h: help, print this message"
+    echo "-r: Create release (zip) to /var/tmp/build"
+    echo "-b: Run this script in batch mode, useful when using without terminal"
+
+}
+
+function f_print_progress_bar {
+
+    docker_build_pid=${1}
+    sp='/-\|'
+    printf ' '
+
+    while kill -0 "${docker_build_pid}" 2>/dev/null; do
+        printf '\r%s %s \b%.1s' "Preparing docker image" "  " "$sp"
+        sp=${sp#?}${sp%???}
+    done
+
+    clear
+
+}
+
+function f_check_distro {
+
+    if [[ $(echo "${distro}" | grep -Ec 'fedora|debian|ubuntu') -ne 1 ]]; then
+
+        echo "Wrong distrution: ${distro}"
+
+        f_usage
+        exit 1
+    fi
+
+}
+
+function f_build_docker_image {
+
+    if [[ ${batch_mode} == "false" ]]; then
+        docker build \
+            -f "docker/${distro}/Dockerfile" \
+            -t "${image}" . >"${pvsneslib_home}/docker/${distro}/docker_build.log" 2>&1 &
+        my_pid=$!
+        f_print_progress_bar ${my_pid}
+        wait ${my_pid}
+    else
+        docker build \
+            -f "docker/${distro}/Dockerfile" \
+            -t "${image}" . >"${pvsneslib_home}/docker/${distro}/docker_build.log" 2>&1
+    fi
+
+    f_print_message "DOCKER" "Building image $image" $?
+
+}
+
+function f_run_docker_container {
+
+    echo -e "[DOCKER] Starting Container ${distro}\n"
+
+    docker run -ti --rm \
+        -w "${pvsneslib_home}" \
+        -v "${pvsneslib_home}:${pvsneslib_home}" \
+        -v "/etc/group:/etc/group:ro" \
+        -v "/etc/passwd:/etc/passwd:ro" \
+        -u "$(id -u):$(id -g)" \
+        -e "PVSNESLIB_HOME=${pvsneslib_home}" \
+        -e "DISTRO=${distro}" \
+        "${image}"
+
+    f_print_message "DOCKER" "Running container with tasks" $?
+
+}
+
+function f_create_zip {
+
+    if [[ "${create_zip}" == "true" ]]; then
+        {
+            [[ -d "${release_path}/pvsneslib" ]] ||
+                mkdir -p "${release_path}/pvsneslib" >/dev/null 2>&1
+            cp -pvr pvsneslib snes-examples devkitsnes \
+                "${release_path}/pvsneslib"
+            cd "${release_path}" || exit 1
+        } >/dev/null 2>&1
+
+        zip -qr "${release_file}.zip" pvsneslib; exit_code=$?
+
+        {
+            rm -rf pvsneslib
+            cd "${pvsneslib_home}" || exit 1
+        } >/dev/null 2>&1
+
+        f_print_message "ZIP" "Building the release file ${release_file}" ${exit_code}
+
+        echo -e "\tThe release file is ${release_path}/${release_file}.zip"
+    fi
+}
+
+function f_print_os_info {
+
+    echo ">>>> SYSTEM INFORMATION" >"${pvsneslib_home}/docker/${distro}/infos.log"
+
+    {
+        echo -n "O.S version "
+        grep -E '^PRETTY_NAME' /etc/os-release |
+            cut -d "=" -f2 |
+            tr -d "\""
+        echo -n "Kernel version "
+        uname -a
+        docker -v
+    } >>"${pvsneslib_home}/docker/${distro}/infos.log"
+    echo
+
+}
+
+function f_print_message {
+
+    #width=50
+
+    action="${1}"
+    message="${2}"
+    status=${3}
+
+    if [[ $status -eq 0 ]]; then
+        fmt_status="PASS"
+    else
+        fmt_status="FAIL"
+    fi
+
+    printf ">>> [%s] %-*s[%s]\n\n" "$action" "$((padding_width - $((${#3} + ${#1}))))" "$message" "$fmt_status"
+
+    [[ $status -eq 0 ]] || exit "$status"
+
+}
+
+function f_quit {
+
+    echo "Do you want to quit ? (y/n)"
+    read -re ctrlc
+    if [ "$ctrlc" = 'y' ]; then
+        exit 1
+    fi
+
+}

--- a/docker/scripts/include/libraries.sh
+++ b/docker/scripts/include/libraries.sh
@@ -29,7 +29,7 @@ function f_print_progress_bar {
 
 function f_check_distro {
 
-    if [[ $(echo "${distro}" | grep -Ec 'fedora|debian|ubuntu') -ne 1 ]]; then
+    if [[ $(echo "${distro}" | grep -Ec '^centos$|^fedora$|^debian$|^ubuntu$') -ne 1 ]]; then
 
         echo "Wrong distrution: ${distro}"
 
@@ -60,7 +60,7 @@ function f_build_docker_image {
 
 function f_run_docker_container {
 
-    echo -e "[DOCKER] Starting Container ${distro}\n"
+    echo -e "[DOCKER] Starting Container ${distro} [...]\n"
 
     docker run -ti --rm \
         -w "${pvsneslib_home}" \

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -7,23 +7,10 @@ ENV DISTRO $DISTRO
 
 RUN apt-get update -y && \
     dpkg --add-architecture i386 && \
-    apt-get install build-essential gcc-multilib git python-is-python3 cmake wget -y
+    apt-get install -y build-essential \
+        gcc-multilib \
+        git python-is-python3 \
+        cmake \
+        wget
 
-CMD /usr/bin/echo -e "\n>>>>> CONTAINER INFORMATIONS" >> ${PVSNESLIB_HOME}/docker/${DISTRO}/infos.log && \
-    /usr/bin/echo -n "O.S version " >> ${PVSNESLIB_HOME}/docker/${DISTRO}/infos.log && \
-    egrep '^PRETTY_NAME' /etc/os-release | \
-        cut -d "=" -f2 |\
-        sed 's/"//g' >> ${PVSNESLIB_HOME}/docker/${DISTRO}/infos.log && \
-    /usr/bin/echo -n "Kernel version " >> ${PVSNESLIB_HOME}/docker/${DISTRO}/infos.log && \
-    uname -a >> ${PVSNESLIB_HOME}/docker/${DISTRO}/infos.log && \
-    /usr/bin/echo "gcc version:" >> ${PVSNESLIB_HOME}/docker/${DISTRO}/infos.log && \
-    gcc -v 2>> ${PVSNESLIB_HOME}/docker/${DISTRO}/infos.log && \
-    /usr/bin/echo -ne "\n\t>> [MAKE]   Cleaning files                   " && \
-    make clean > ${PVSNESLIB_HOME}/docker/${DISTRO}/make_clean.log 2>&1 && \
-    /usr/bin/echo -e "[PASS]\n" || { echo -e "[FAILED]\n"; exit 1; } && \
-    /usr/bin/echo -ne "\t>> [GIT]    Refreshing source code           " && \
-    git submodule update --init > ${PVSNESLIB_HOME}/docker/${DISTRO}/git_refresh.log 2>&1 && \
-    /usr/bin/echo -e "[PASS]\n" || { echo -e "[FAILED]\n"; exit 1; } && \
-    /usr/bin/echo -ne "\t>> [MAKE]   Compiling code and installing it " && \
-    make > ${PVSNESLIB_HOME}/docker/${DISTRO}/make.log 2>&1 && \
-    /usr/bin/echo -e "[PASS]\n" || { echo -e "[FAILED]\n"; exit 1; }
+CMD ./docker/scripts/container.sh "${PVSNESLIB_HOME}" "${DISTRO}"

--- a/dockerrun.sh
+++ b/dockerrun.sh
@@ -1,154 +1,65 @@
 #!/bin/bash
 
-function f_usage {
-
-    echo "usage: ${0} options:<d|h|c>"
-    echo "-d: name of the linux distrubtion (fedora, ubuntu or debian)"
-    echo "-h: help, print this message"
-    echo "-r: Create release (zip) to /var/tmp/build"
-
-}
-
-function f_check_distro {
-
-    distro="${1}"
-
-    if [[ $(echo ${distro} | egrep -c 'fedora|debian|ubuntu') -ne 1 ]]; then
-
-        echo "Wrong distrution: ${distro}"
-
-        f_usage
-        exit 1
-    fi
-
-}
-
-function f_delete_none_image {
-
-    is_none=$(docker image ls | grep -c none)
-
-    if [[ ${is_none} -ne 0 ]]; then
-
-        echo ">> [DOCKER] cleaning ${is_none} <none> image(s)"
-
-        docker image ls |
-            grep none |
-            awk '{print $3}' |
-            xargs docker image rm --force >/dev/null 2>&1
-    fi
-
-}
-
-function f_create_zip {
-
-    image="${1}"
-    rc=0
-    realease_path="/var/tmp/build"
-
-    echo -en "\n>> [ZIP] Building release for ${image} "
-    mkdir -p ${realease_path}/pvsneslib >/dev/null 2>&1
-    cp -pvr pvsneslib snes-examples devkitsnes \
-        ${realease_path}/pvsneslib >/dev/null 2>&1
-    cd ${realease_path} >/dev/null 2>&1
-    zip -r ./${image}.zip \
-        pvsneslib >/dev/null 2>&1
-    rc=$?
-    rm -rf pvsneslib
-    cd - >/dev/null 2>&1
-    if [[ ${rc} -eq 0 ]]; then
-        echo -e "[PASS]\n"
-    else
-        echo -e "[FAILED]\n"
-        exit ${rc}
-    fi
-    echo -e "The release is ${realease_path}/${image}.zip"
-}
-
-function f_print_os_info {
-
-    echo ">>>> SYSTEM INFORMATION" >$(pwd)/docker/${distro}/infos.log
-    echo -n "O.S version " >>$(pwd)/docker/${distro}/infos.log
-    egrep '^PRETTY_NAME' /etc/os-release |
-        cut -d "=" -f2 |
-        sed 's/"//g' >>$(pwd)/docker/${distro}/infos.log
-    echo -n "Kernel version " >>$(pwd)/docker/${distro}/infos.log
-    uname -a >>$(pwd)/docker/${distro}/infos.log
-    docker -v >>$(pwd)/docker/${distro}/infos.log
-    echo
-
-}
-
-function f_quit {
-
-    echo "Do you want to quit ? (y/n)"
-    read -e ctrlc
-    if [ "$ctrlc" = 'y' ]; then
-        exit
-    fi
-
-}
-
 # --------------- #
 # M A I N
 # --------------- #
+
+source "./docker/scripts/include/libraries.sh"
 
 trap f_quit SIGINT
 trap f_quit SIGTERM
 
 clear
 
-unset -v distro
-
 no_args="true"
 create_zip="false"
+pvsneslib_home="$(pwd)"
+padding_width=50
+batch_mode="false"
 
-while getopts "d:rh" flag; do
+while getopts ":d:r:hb" flag; do
     case "${flag}" in
     d)
         distro=${OPTARG}
-        f_check_distro ${distro}
+        f_check_distro
+        release_file="pvsneslib-${distro}"
+        image="${release_file}-image"
         ;;
     h)
         f_usage
         exit 0
         ;;
     r)
+        release_path=${OPTARG:=/var/tmp/build}
         create_zip="true"
+        ;;
+    b)
+        batch_mode="true"
+        ;;
+    *)
+        f_usage
+        exit 1
         ;;
     esac
     no_args="false"
 done
+
+export padding_width \
+    release_path \
+    create_zip \
+    batch_mode \
+    pvsneslib_home \
+    image
 
 [[ "$no_args" == "true" ]] && {
     f_usage
     exit 1
 }
 
-f_delete_none_image
-
 f_print_os_info
 
-release_file="pvsneslib-${distro}"
-image="${release_file}-image"
+f_build_docker_image
 
-echo -n ">> [DOCKER] Building image ${image} "
-docker build \
-    -f docker/${distro}/Dockerfile \
-    -t ${image} . >$(pwd)/docker/${distro}/docker_build.log 2>&1
-echo -e "[PASS]\n" || {
-    echo -e "[FAILED]\n"
-    exit 1
-}
+f_run_docker_container
 
-echo ">> [DOCKER] Running container ${image}..."
-docker run -ti --rm \
-    -w "$(pwd)" \
-    -v "$(pwd):$(pwd)" \
-    -v "/etc/group:/etc/group:ro" \
-    -v "/etc/passwd:/etc/passwd:ro" \
-    -u "$(id -u):$(id -g)" \
-    -e "PVSNESLIB_HOME=$(pwd)" \
-    -e "DISTRO=${distro}" \
-    ${image}
-
-[[ "$create_zip" == "true" ]] && f_create_zip ${release_file}
+f_create_zip


### PR DESCRIPTION
Hi,

Here few updates on docker integration:

* Add package to fedora Dockerfile to build against develop branch

* Refactor dockerrun.sh to avoid code repetition

* Add possibility to provide a custom path to build release (zip)

* Simplify Dockerfiles CMD

* Add centos Dockerfile

* Write a descente Readme

* Some improvements on fedora to build the image faster (mirror lists are very slow)

* Remove infos relative to container as we can easily reproduce it, but not for the operating system

* Remove the function to delete <none> image, it can produces problems when many images are building in the same time as docker creates a <none> image until the final image creation is finished. So this tasks was dangerous and should be performed manualy.
