### PR TITLE
feat: colored errors for gfx2snes more noticeable

### DIFF
--- a/tools/gfx2snes/gfx2snes.c
+++ b/tools/gfx2snes/gfx2snes.c
@@ -38,6 +38,8 @@
 #include "lodepng.h"
 #include "loadimg.h"
 
+#define RED_ERROR "\e[0;31merror\e[0m '"	// ANSI color codes for more noticeable errors
+
 int	border=1;						// options and their defaults
 int	packed=0;						//
 int size=0;							//
@@ -121,7 +123,7 @@ void PrintOptions(char *str)
 	printf("\n  where filename is a 256 color PNG, BMP, PCX or TGA file");
 
 	if(str[0]!=0)
-		printf("\ngfx2snes: error 'The [%s] parameter is not recognized'",str);
+		printf("\ngfx2snes: %s 'The [%s] parameter is not recognized'", RED_ERROR, str);
 
 	printf("\n\nOptions are:");
 	printf("\n\n--- Graphics options ---");
@@ -385,21 +387,21 @@ int main(int argc, char **arg)
 
 	if( filebase[0] == 0 )
 	{
-		printf("\ngfx2snes: error 'You must specify a base filename'");
+		printf("\ngfx2snes: %s 'You must specify a base filename'", RED_ERROR);
 		PrintOptions("");
 		return 1;
 	}
 
 	if( colors == 0 )
 	{
-		printf("\ngfx2snes: error 'The Number of Colors parameter must be specified'");
+		printf("\ngfx2snes: %s 'The Number of Colors parameter must be specified'", RED_ERROR);
 		PrintOptions("");
 		return 1;
 	}
 
 	if((size == 0) && (border == 0) && (screen == 0))
 	{
-		printf("\ngfx2snes: error 'The Size parameter must be specified when the border is turned off'");
+		printf("\ngfx2snes: %s 'The Size parameter must be specified when the border is turned off'", RED_ERROR);
 		PrintOptions("");
 		return 1;
 	}
@@ -450,7 +452,7 @@ int main(int argc, char **arg)
 	if((size == 0) && (screen == 0))
 	{
 		if (quietmode == 0)
-			printf("\ngfx2snes: error 'Auto-detecting size of image blocks...'");
+			printf("\ngfx2snes: %s 'Auto-detecting size of image blocks...'", RED_ERROR);
 
 		clr = image.buffer[0]; //get the border color
 		for(i=1; i<width; i++)
@@ -475,7 +477,7 @@ int main(int argc, char **arg)
 
 		if( (xsize%(size+1) != 0 ) || (ysize%(size+1) != 0 ) )
 		{
-			printf("\ngfx2snes: error 'Border format is incorrect... autodetect size failed.'\n");
+			printf("\ngfx2snes: %s 'Border format is incorrect... autodetect size failed.'\n", RED_ERROR);
 			return 1;
 		}
 
@@ -492,7 +494,7 @@ int main(int argc, char **arg)
 			// Get out if hires and not 512 width
 			if( (hi512) &&  (width != 512) )
 			{
-				printf("\ngfx2snes: error 'EHiRes mode 5 format is not 512 pixels width.'\n");
+				printf("\ngfx2snes: %s 'EHiRes mode 5 format is not 512 pixels width.'\n", RED_ERROR);
 				return 1;
 			}
 		}
@@ -599,7 +601,7 @@ int main(int argc, char **arg)
 
 		if(buffer==NULL)
 		{
-			printf("\ngfx2snes: error 'Not enough memory to do image operations...'\n");
+			printf("\ngfx2snes: %s 'Not enough memory to do image operations...'\n", RED_ERROR);
 			return 1;
 		}
 
@@ -618,7 +620,7 @@ int main(int argc, char **arg)
 		if(tilemap==NULL)
 		{
 			free(buffer);
-			printf("\ngfx2snes: error 'Not enough memory to do tile map optimizations...'\n");
+			printf("\ngfx2snes: %s 'Not enough memory to do tile map optimizations...'\n", RED_ERROR);
 			return 1;
 		}
 
@@ -630,7 +632,7 @@ int main(int argc, char **arg)
 
 		if((screen == 7) && (num_tiles+blank_absent)>256)
 		{
-			printf("\ngfx2snes: error 'Need %d tiles to represent the screen in mode7. SNES only has room for 256 tiles'" ,num_tiles+blank_absent);
+			printf("\ngfx2snes: %s 'Need %d tiles to represent the screen in mode7. SNES only has room for 256 tiles'", RED_ERROR, num_tiles+blank_absent);
 			free(tilemap);
 			return 1;
 		}
@@ -650,7 +652,7 @@ int main(int argc, char **arg)
 
 		if(buffer==NULL)
 		{
-			printf("\ngfx2snes: error 'Not enough memory to do image operations...'\n");
+			printf("\ngfx2snes: %s' Not enough memory to do image operations...'\n", RED_ERROR);
 			return 1;
 		}
 
@@ -663,7 +665,7 @@ int main(int argc, char **arg)
 
 		if(temp==NULL)
 		{
-			printf("\ngfx2snes: error 'Not enough memory to do image operations...'\n");
+			printf("\ngfx2snes: %s 'Not enough memory to do image operations...'\n", RED_ERROR);
 			return 1;
 		}
 
@@ -705,7 +707,7 @@ int main(int argc, char **arg)
 		fp = fopen(filename,"wb");
 		if(fp==NULL)
 		{
-			printf("\ngfx2snes: error 'Can't open file [%s] for writing'\n",filename);
+			printf("\ngfx2snes: %s 'Can't open file [%s] for writing'\n", RED_ERROR, filename);
 			free(tilemap);
 			return 1;
 		}
@@ -739,7 +741,7 @@ int main(int argc, char **arg)
 			fp = fopen(filename,"wb");
 			if(fp==NULL)
 			{
-				printf("\ngfx2snes: error 'Can't open file [%s] for writing'\n",filename);
+				printf("\ngfx2snes: %s Can't open file [%s] for writing'\n", RED_ERROR, filename);
 				free(tilemap);
 				return 1;
 			}
@@ -769,7 +771,7 @@ int main(int argc, char **arg)
 
 		if(fp==NULL)
 		{
-			printf("\ngfx2snes: error 'Can't open file [%s] for writing'\n",filename);
+			printf("\ngfx2snes: %s 'Can't open file [%s] for writing'\n", RED_ERROR, filename);
 			return 0;
 		}
 


### PR DESCRIPTION
it's easy to miss when a more mild error occurs in gfx2snes so I think it would be good if they were colored red