### PR TITLE
feat: add function to insert Mesen breakpoint using the 65816's WDM opcode

### DIFF
--- a/pvsneslib/source/consoles.asm
+++ b/pvsneslib/source/consoles.asm
@@ -86,7 +86,19 @@ rand:
     rtl
 .ENDS
 
+;---------------------------------------------------------------------------
+; void consoleMesenBreakpoint()
+.SECTION ".mesen_breakpoint" SUPERFREE
+
+consoleMesenBreakpoint:
+    .byte $42, $00	// 42h is the opcode for WDM and 00h is the signature byte
+			// WLA has since been fixed to allow multibyte WDM
+    rtl
+
+.ENDS
+
 .SECTION ".consoles1_text" SUPERFREE
+
 
 ;---------------------------------------------------------------------------
 ; void consoleNocashMessage(char *fmt, ...)


### PR DESCRIPTION
I do think we should eventually move this to a file called emulators.asm eventually, but it's a start so people on the develop branch can get some experience using it.

Make sure you have "Break on" WDM checked in Mesen 2's debugger.