### PR TITLE
Remove warnings message during snesbrr compilation

### DIFF
--- a/tools/snesbrr/base/basemath.h
+++ b/tools/snesbrr/base/basemath.h
@@ -63,14 +63,8 @@ namespace base
         template <uint N, typename T>
         inline static T clamp(T x)
         {
-            enum
-            {
-                low = -1 << (N - 1)
-            };
-            enum
-            {
-                high = (1 << (N - 1)) - 1
-            };
+            const T low  = static_cast<T>(-1) << (N - 1);
+            const T high = (1 << (N - 1)) - 1;
 
             if (x > high)
                 x = high;
@@ -83,10 +77,7 @@ namespace base
         template <uint N, typename T>
         inline static T uclamp(T x)
         {
-            enum
-            {
-                high = (((1 << (N - 1)) - 1) << 1) + 1
-            };
+            const T high = (static_cast<T>(1) << N) - 1;
 
             if (x > high)
                 x = high;


### PR DESCRIPTION
Hi all,

 Here a very small change to avoid warnings messages during the `snesbrr` compilation:

```
basemath.h: In instantiation of ‘T base::math::clamp(T) [with unsigned int N = 16; T = int]’:
BrrCodec.cpp:202:30:   required from here
../base/basemath.h:68:26: warning: left operand of shift expression ‘(-1 << 15)’ is negative [-fpermissive]
   68 |                 low = -1 << (N - 1)
      |                       ~~~^~~~~~~~~~
../base/basemath.h: In instantiation of ‘T base::math::clamp(T) [with unsigned int N = 15; T = int]’:
BrrCodec.cpp:244:26:   required from here
../base/basemath.h:68:26: warning: left operand of shift expression ‘(-1 << 14)’ is negative [-fpermissive]
../base/basemath.h: In instantiation of ‘T base::math::clamp(T) [with unsigned int N = 4; T = int]’:
BrrCodec.cpp:441:34:   required from here
../base/basemath.h:68:26: warning: left operand of shift expression ‘(-1 << 3)’ is negative [-fpermissive]
Compiling main.cpp
```
The errors are warnings generated by the compiler indicating that the left operand of a shift expression in the "basemath.h" header file is negative. Specifically, the warnings are related to the left shift operation (-1 << N - 1) used in the implementation of the "clamp" function.

The "clamp" function is a template function that takes a single parameter of type T and returns a value that is limited to a range of [0, 2^N - 1], where N is an unsigned integer template parameter.

In the warning message, the compiler is pointing out that the expression (-1 << (N - 1)) is resulting in a negative value, which can lead to undefined behavior in C++. This is because the left shift operator shifts the bits of the operand to the left and fills the vacated bits with zeroes. However, when the left operand is negative, the result of the left shift is implementation-defined in C++.

To fix this warning, we modify the implementation of the "clamp" function in the "basemath.h" header file to use an unsigned integer instead of a signed integer for the "low" variable. we also use the "static_cast" operator to convert the result of the left shift operation to an unsigned integer.


