### PR TITLE
Optimize and simplify Makefile for tools/

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,22 +1,8 @@
 SUBDIRS := gfx2snes smconv bin2txt constify snestools snesbrr tmx2snes 816-opt
 
-all: $(SUBDIRS)
+.PHONY: all clean install $(SUBDIRS)
+
+all clean install: $(SUBDIRS)
 
 $(SUBDIRS):
-	make -C $@
-
-clean:
-	for f in $(SUBDIRS); do \
-	 cd $$f ; \
-	 make clean ; \
-	 cd .. ; \
-	done
-
-install:
-	for f in $(SUBDIRS); do \
-	 cd $$f ; \
-	 make install ; \
-	 cd .. ; \
-	done
-
-.PHONY: all $(SUBDIRS)
+	$(MAKE) -C $@ $(MAKECMDGOALS)


### PR DESCRIPTION
Hi all,

 Here a small update for the `tools/Makefile` to optimize it.

 This optimized `Makefile` simplifies the code and reduces duplication by using the automatic variable `$(MAKECMDGOALS)` to pass the command goal (all, clean, or install) to the sub-Make processes. Here's a breakdown of the changes:

The phony targets are listed together with the `SUBDIRS` variable, which makes the `Makefile` more readable and easier to maintain.

The all, clean, and install targets all depend on the subdirectories, so they can be listed together with the PHONY target, and then listed as prerequisites for each of the targets.

The rule to build each subdirectory is simplified using the $(MAKE) command and the automatic variable $@, which represents the current subdirectory. The `$(MAKECMDGOALS)` variable is used to pass the command goal to the sub-Make process, which avoids the need to duplicate the rules for each target.

The `cd` commands in the clean and install targets are unnecessary because `$(MAKE)` changes the directory to the subdirectory automatically. Instead, we use the `$@` variable to pass the subdirectory name to the `$(MAKE)` command.

By using these optimizations, we can make the `Makefile` more concise and easier to read and maintain.



 