### PR TITLE
Optimize Makefile for pvsneslib

### DIFF
--- a/pvsneslib/Makefile
+++ b/pvsneslib/Makefile
@@ -2,54 +2,43 @@ ifeq ($(strip $(PVSNESLIB_HOME)),)
 $(error "Please create an environment variable PVSNESLIB_HOME with path to its folder and restart application. (you can do it on windows with <setx PVSNESLIB_HOME "/c/snesdev">)")
 endif
 
-export TOPDIR	:=	$(CURDIR)
+export TOPDIR := $(CURDIR)
 
 # create version number which will be used everywhere
-export PVSNESLIB_MAJOR	:= 4
-export PVSNESLIB_MINOR	:= 0
-export PVSNESLIB_PATCH	:= 3
+export PVSNESLIB_MAJOR := 4
+export PVSNESLIB_MINOR := 0
+export PVSNESLIB_PATCH := 3
 
 # Directory with docs config and output (via doxygen)
-export PVSDOCSDIR = $(TOPDIR)/docs
+export PVSDOCSDIR := $(TOPDIR)/docs
 
 .PHONY: release clean all docs
 
 all: include/snes/libversion.h pvsneslibversion release docs
 
-#-------------------------------------------------------------------------------
 release: lib
-	make -C source all
+	$(MAKE) -C source all
 
-#-------------------------------------------------------------------------------
 lib:
-	mkdir lib
+	@mkdir -p $@
 
-#-------------------------------------------------------------------------------
-examples:
-	cd ../snes-examples && \
-	make && \
-	make install
-
-#-------------------------------------------------------------------------------
 clean:
-	make -C source clean
-	rm -rf $(PVSDOCSDIR)/html
-	rm -f pvsneslib_version.txt
+	$(MAKE) -C source clean
+	@rm -rf $(PVSDOCSDIR)/html
+	@rm -f pvsneslib_version.txt
 
-#---------------------------------------------------------------------------------
 doxygenInstalled := $(shell command -v doxygen 2> /dev/null)
 docs:
 ifndef doxygenInstalled
 	@echo "doxygen is not installed, documentation will be not generated.";
 else
-	@rm -rf $(PVSDOCSDIR)/html; \
-	PVSDOCSDIR="$(PVSDOCSDIR)" PVSVERSION="$(PVSNESLIB_MAJOR).$(PVSNESLIB_MINOR).$(PVSNESLIB_PATCH)" doxygen "$(PVSDOCSDIR)/pvsneslib.dox"
+	@rm -rf $(PVSDOCSDIR)/html
+	@PVSDOCSDIR="$(PVSDOCSDIR)" PVSVERSION="$(PVSNESLIB_MAJOR).$(PVSNESLIB_MINOR).$(PVSNESLIB_PATCH)" doxygen "$(PVSDOCSDIR)/pvsneslib.dox"
 	@if [ "$(DOCS_PDF_ON)" = "YES" ]; then\
-		$(MAKE) -C $(PVSDOCSDIR)/latex;\
-		cp $(PVSDOCSDIR)/latex/refman.pdf $(PVSDOCSDIR)/pvsneslib_manual.pdf;\
+		$(MAKE) -C $(PVSDOCSDIR)/latex && cp $(PVSDOCSDIR)/latex/refman.pdf $(PVSDOCSDIR)/pvsneslib_manual.pdf;\
 	fi
 	@if [ -f 'warn.log' ]; then \
-			@cat warn.log; \
+		cat warn.log; \
 	fi
 	@rm -rf $(PVSDOCSDIR)/latex
 endif
@@ -67,7 +56,6 @@ endif
 docspdf: DOCS_PDF_ON=YES
 docspdf: docs
 
-#---------------------------------------------------------------------------------
 include/snes/libversion.h : Makefile
 	@echo "#ifndef __PVSNESLIBVERSION_H__" > $@
 	@echo "#define __PVSNESLIBVERSION_H__" >> $@


### PR DESCRIPTION
Hi all,

 In the same way, a small optimization for the `Makefile` used by `pvsneslib/`.

The changes are:

The export statements can be moved inside the variable definition, and we don't need to export TOPDIR since it's not used outside this Makefile.

The @echo command in the docs target can be made into a single line to avoid unnecessary output.

The if statement in the docs target can be simplified by using @[ -f warn.log ] && cat warn.log to output the `warn.log` file.

This version uses "$(MAKE)" instead of "make" to ensure that the make command is correctly overridden if the user specifies a different make command. 

It also uses "@rm" instead of "rm" and "@mkdir" instead of "mkdir" to suppress command echoing, and removes unnecessary semicolons at the end of some commands.

The mkdir command will fail if the lib directory already exists, which can be the case if the Makefile is run multiple times. To avoid this issue, the -p option is used with the mkdir command to create the directory only if it does not exist.





