### PR TITLE
constify: Remove extra new line when version is printed, optimize Makefile as well

### DIFF
--- a/tools/constify/Makefile
+++ b/tools/constify/Makefile
@@ -36,7 +36,7 @@ lzss.o : lzss.c
 	$(CC) $(CFLAGS) -c $<
 
 clean:
-	rm -f $(EXE)$(EXT) $(OBJS)
+	@rm -f $(EXE)$(EXT) $(OBJS)
 
 install:
-	cp $(EXE)$(EXT) ../../devkitsnes/tools/$(EXE)$(EXT)
+	@cp $(EXE)$(EXT) ../../devkitsnes/tools/$(EXE)$(EXT)

--- a/tools/constify/Makefile
+++ b/tools/constify/Makefile
@@ -1,11 +1,12 @@
 VERSION := 4.0.0
+DATESTRING := $(shell date +%Y%m%d)
 
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------
 CC := g++
 CFLAGS := -g -O2 -Wall -Wno-literal-suffix -Wno-overflow
-DEFINES := -D__BUILD_DATE="\"`date +'%Y%m%d'`\"" -D__BUILD_VERSION="\"$(VERSION)\""
+DEFINES := -D__BUILD_DATE="\"$(DATESTRING)\"" -D__BUILD_VERSION="\"$(VERSION)\""
 
 # We want to build the project with static libraries except for Mac OS because the manual page of gcc explain:
 # "The static option will not work on Mac OS X unless all libraries (including libgcc.a) have also been compiled with -static.

--- a/tools/constify/Makefile
+++ b/tools/constify/Makefile
@@ -1,50 +1,47 @@
-VERSION = "4.0.0"
+VERSION := 4.0.0
 
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------
-CC=g++
-CFLAGS=-g -O2 -Wall -Wno-literal-suffix -Wno-overflow -D__BUILD_DATE="\"`date +'%Y%m%d'`\"" -D__BUILD_VERSION="\"$(VERSION)\""
+CC := g++
+CFLAGS := -g -O2 -Wall -Wno-literal-suffix -Wno-overflow
+DEFINES := -D__BUILD_DATE="\"`date +'%Y%m%d'`\"" -D__BUILD_VERSION="\"$(VERSION)\""
 
 # We want to build the project with static libraries except for Mac OS because the manual page of gcc explain:
 # "The static option will not work on Mac OS X unless all libraries (including libgcc.a) have also been compiled with -static.
 # Since neither a static version of libSystem.dylib nor crt0.o are provided, this option is not useful to most people."
-ifneq ($(shell uname -s),Darwin)
-CFLAGS+=-static
+ifeq ($(shell uname -s),Darwin)
+    LIBS :=
+else
+    CFLAGS += -static
+    LIBS := -lm
 endif
 
-SOURCES=constify.cpp
-OBJS=constify.o
-EXE=constify
-DEFINES=
-LIBS=
+SOURCES := constify.cpp
+OBJS := $(SOURCES:%.cpp=%.o)
+EXE := constify
 
 ifeq ($(OS),Windows_NT)
-        EXT=.exe
+    EXT := .exe
 else
-        EXT=
+    EXT :=
 endif
 
 #---------------------------------------------------------------------------------
 all: $(EXE)$(EXT)
 
 #---------------------------------------------------------------------------------
-$(EXE)$(EXT) : $(OBJS)
-	@echo make exe $(notdir $<)
-	$(CC) $(CFLAGS) $(OBJS) -o $@
+$(EXE)$(EXT): $(OBJS)
+	@echo "linking $@"
+	$(CC) $(CFLAGS) $(DEFINES) $(LIBS) $(OBJS) -o $@
 
-constify.o : constify.cpp
-	@echo make obj $(notdir $<)
-	$(CC) $(CFLAGS) -c $<
-
-lzss.o : lzss.c
-	@echo make obj $(notdir $<)
-	$(CC) $(CFLAGS) -c $<
+%.o: %.cpp
+	@echo "compiling $<"
+	$(CC) $(CFLAGS) $(DEFINES) -c $< -o $@
 
 #---------------------------------------------------------------------------------
 clean:
 	rm -f $(EXE)$(EXT) $(OBJS)
 
-install:
+install: $(EXE)$(EXT)
 	cp $(EXE)$(EXT) ../../devkitsnes/tools/$(EXE)$(EXT)
-

--- a/tools/constify/Makefile
+++ b/tools/constify/Makefile
@@ -18,7 +18,7 @@ else
     LIBS := -lm
 endif
 
-SOURCES := constify.cpp
+SOURCES := $(wildcard *.cpp)
 OBJS := $(SOURCES:%.cpp=%.o)
 EXE := constify
 

--- a/tools/constify/Makefile
+++ b/tools/constify/Makefile
@@ -42,7 +42,7 @@ $(EXE)$(EXT): $(OBJS)
 
 #---------------------------------------------------------------------------------
 clean:
-	rm -f $(EXE)$(EXT) $(OBJS)
+	@rm -f $(EXE)$(EXT) $(OBJS)
 
 install: $(EXE)$(EXT)
-	cp $(EXE)$(EXT) ../../devkitsnes/tools/$(EXE)$(EXT)
+	@cp $(EXE)$(EXT) ../../devkitsnes/tools/$(EXE)$(EXT)

--- a/tools/constify/Makefile
+++ b/tools/constify/Makefile
@@ -1,50 +1,42 @@
-VERSION := 4.0.0
-DATESTRING := $(shell date +%Y%m%d)
+VERSION = "4.0.0"
 
-#---------------------------------------------------------------------------------
-# options for code generation
-#---------------------------------------------------------------------------------
-CC := g++
-CFLAGS := -g -O2 -Wall -Wno-literal-suffix -Wno-overflow
-DEFINES := -D__BUILD_DATE="\"$(DATESTRING)\"" -D__BUILD_VERSION="\"$(VERSION)\""
+CC=g++
+CFLAGS=-g -O2 -Wall -Wno-literal-suffix -Wno-overflow -D__BUILD_DATE="\"`date +'%Y%m%d'`\"" -D__BUILD_VERSION="\"$(VERSION)\""
 
 # We want to build the project with static libraries except for Mac OS because the manual page of gcc explain:
-# "The static option will not work on Mac OS X unless all libraries (including libgcc.a) have also been compiled with -static.
-# Since neither a static version of libSystem.dylib nor crt0.o are provided, this option is not useful to most people."
-ifeq ($(shell uname -s),Darwin)
-    LIBS :=
-else
-    CFLAGS += -static
-    LIBS := -lm
+# "The static option will not work on Mac OS X unless all libraries (including libgcc.a) have also been compiled with -static. Since neither a static version of libSystem.dylib nor crt0.o are provided, this option is not useful to most people."
+ifneq ($(shell uname -s),Darwin)
+CFLAGS+=-static
 endif
 
-SOURCES := constify.cpp
-OBJS := $(SOURCES:%.cpp=%.o)
-EXE := constify
+SOURCES=constify.cpp
+OBJS=constify.o
+EXE=constify
+DEFINES=
+LIBS=
 
 ifeq ($(OS),Windows_NT)
-    EXT := .exe
+        EXT=.exe
 else
-    EXT :=
+        EXT=
 endif
 
-#---------------------------------------------------------------------------------
 all: $(EXE)$(EXT)
 
-#---------------------------------------------------------------------------------
-$(EXE)$(EXT): $(OBJS)
-	@echo "linking $@"
-	$(CC) $(CFLAGS) $(DEFINES) $(LIBS) $(OBJS) -o $@
+$(EXE)$(EXT) : $(OBJS)
+	@echo make exe $(notdir $<)
+	$(CC) $(CFLAGS) $(OBJS) -o $@
 
-%.o: %.cpp
-	@echo "compiling $<"
-	$(CC) $(CFLAGS) $(DEFINES) -c $< -o $@
+constify.o : constify.cpp
+	@echo make obj $(notdir $<)
+	$(CC) $(CFLAGS) -c $<
 
-#---------------------------------------------------------------------------------
+lzss.o : lzss.c
+	@echo make obj $(notdir $<)
+	$(CC) $(CFLAGS) -c $<
+
 clean:
-	@rm -f $(EXE)$(EXT) $(OBJS)
+	rm -f $(EXE)$(EXT) $(OBJS)
 
-install: $(EXE)$(EXT)
-	@cp $(EXE)$(EXT) ../../devkitsnes/tools/$(EXE)$(EXT)
-
-.PHONY: all clean install
+install:
+	cp $(EXE)$(EXT) ../../devkitsnes/tools/$(EXE)$(EXT)

--- a/tools/constify/Makefile
+++ b/tools/constify/Makefile
@@ -46,3 +46,5 @@ clean:
 
 install: $(EXE)$(EXT)
 	@cp $(EXE)$(EXT) ../../devkitsnes/tools/$(EXE)$(EXT)
+
+.PHONY: all clean install

--- a/tools/constify/Makefile
+++ b/tools/constify/Makefile
@@ -1,42 +1,50 @@
-VERSION = "4.0.0"
+VERSION := 4.0.0
+DATESTRING := $(shell date +%Y%m%d)
 
-CC=g++
-CFLAGS=-g -O2 -Wall -Wno-literal-suffix -Wno-overflow -D__BUILD_DATE="\"`date +'%Y%m%d'`\"" -D__BUILD_VERSION="\"$(VERSION)\""
+#---------------------------------------------------------------------------------
+# options for code generation
+#---------------------------------------------------------------------------------
+CC := g++
+CFLAGS := -g -O2 -Wall -Wno-literal-suffix -Wno-overflow
+DEFINES := -D__BUILD_DATE="\"$(DATESTRING)\"" -D__BUILD_VERSION="\"$(VERSION)\""
 
 # We want to build the project with static libraries except for Mac OS because the manual page of gcc explain:
-# "The static option will not work on Mac OS X unless all libraries (including libgcc.a) have also been compiled with -static. Since neither a static version of libSystem.dylib nor crt0.o are provided, this option is not useful to most people."
-ifneq ($(shell uname -s),Darwin)
-CFLAGS+=-static
+# "The static option will not work on Mac OS X unless all libraries (including libgcc.a) have also been compiled with -static.
+# Since neither a static version of libSystem.dylib nor crt0.o are provided, this option is not useful to most people."
+ifeq ($(shell uname -s),Darwin)
+    LIBS :=
+else
+    CFLAGS += -static
+    LIBS := -lm
 endif
 
-SOURCES=constify.cpp
-OBJS=constify.o
-EXE=constify
-DEFINES=
-LIBS=
+SOURCES := constify.cpp
+OBJS := $(SOURCES:%.cpp=%.o)
+EXE := constify
 
 ifeq ($(OS),Windows_NT)
-        EXT=.exe
+    EXT := .exe
 else
-        EXT=
+    EXT :=
 endif
 
+#---------------------------------------------------------------------------------
 all: $(EXE)$(EXT)
 
-$(EXE)$(EXT) : $(OBJS)
-	@echo make exe $(notdir $<)
-	$(CC) $(CFLAGS) $(OBJS) -o $@
+#---------------------------------------------------------------------------------
+$(EXE)$(EXT): $(OBJS)
+	@echo "linking $@"
+	$(CC) $(CFLAGS) $(DEFINES) $(LIBS) $(OBJS) -o $@
 
-constify.o : constify.cpp
-	@echo make obj $(notdir $<)
-	$(CC) $(CFLAGS) -c $<
+%.o: %.cpp
+	@echo "compiling $<"
+	$(CC) $(CFLAGS) $(DEFINES) -c $< -o $@
 
-lzss.o : lzss.c
-	@echo make obj $(notdir $<)
-	$(CC) $(CFLAGS) -c $<
-
+#---------------------------------------------------------------------------------
 clean:
 	@rm -f $(EXE)$(EXT) $(OBJS)
 
-install:
+install: $(EXE)$(EXT)
 	@cp $(EXE)$(EXT) ../../devkitsnes/tools/$(EXE)$(EXT)
+
+.PHONY: all clean install

--- a/tools/constify/constify.cpp
+++ b/tools/constify/constify.cpp
@@ -30,12 +30,12 @@
 
 */
 
+#include <iterator>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <string>
 #include <vector>
-#include <iterator>
 
 #define CONSTIFYVERSION __BUILD_VERSION
 #define CONSTIFYDATE __BUILD_DATE
@@ -138,7 +138,7 @@ void PrintOptions(const char *str)
 //////////////////////////////////////////////////////////////////////////////
 void PrintVersion(void)
 {
-    printf("\n\nconstify.exe (" CONSTIFYDATE ") version " CONSTIFYVERSION "");
+    printf("constify.exe (" CONSTIFYDATE ") version " CONSTIFYVERSION "");
     printf("\nCopyright (c) 2013-2021 Alekmaul");
     printf("\nBased on constify by Mic\n");
 }
@@ -152,7 +152,7 @@ int main(int argc, char **argv)
     unsigned int i, j;
     int k;
     int varOffs, varSize = 0, varsMoved, bytesMoved, ch, currSection;
-    char cFilebase[256] = "";
+    char cFilebase[256]   = "";
     char asmFilebase[256] = "";
     char outFilebase[256] = "";
 
@@ -286,7 +286,7 @@ int main(int argc, char **argv)
     }
 
     oneLine.clear();
-    saveCode = false;
+    saveCode    = false;
     currSection = -1;
     while (1)
     {
@@ -299,20 +299,20 @@ int main(int argc, char **argv)
                     // if (oneLine.find(".RAMSECTION \"ram.data\"") != string::npos)
                     if (oneLine.find("APPENDTO \"globram.data\"") != string::npos)
                     {
-                        saveCode = true;
+                        saveCode    = true;
                         currSection = 0;
                         asmSections[currSection].push_back(oneLine);
                     }
                     // else if (oneLine.find(".SECTION \".data\"") != string::npos)
                     else if (oneLine.find("APPENDTO \"glob.data\"") != string::npos)
                     {
-                        saveCode = true;
+                        saveCode    = true;
                         currSection = 1;
                         asmSections[currSection].push_back(oneLine);
                     }
                     else if (oneLine.find(".SECTION \".rodata\"") != string::npos)
                     {
-                        saveCode = true;
+                        saveCode    = true;
                         currSection = 2;
                         if (sectName.length())
                         {
@@ -360,7 +360,7 @@ int main(int argc, char **argv)
     {
         unsigned int k, m;
         int n;
-        j = 1;
+        j       = 1;
         varOffs = 0;
         while (j < asmSections[0].size())
         {
@@ -387,7 +387,7 @@ int main(int argc, char **argv)
                 varSize = atoi(asmSections[0][j].substr(k + 4).data());
             }
             int dataOffs = 0;
-            m = 1;
+            m            = 1;
             while ((dataOffs < varOffs) && (m < asmSections[1].size()))
             {
                 n = 1;


### PR DESCRIPTION
Hi all,

 Some small improvements for `constify`. I slighty optimized the `Makefile` and remove useless new lines in `constify.c` when printing version.

In this optimized version, I made the following improvements:

- Consolidated common flags into `CFLAGS` and `DEFINES` variables
- Uses `:=` instead of `=` for variable assignment to prevent unnecessary re-evaluation.
- Uses `$(shell date +%Y%m%d)` instead of invoking the date command multiple times.
- Moved the platform-specific `LIBS` flag into an `ifeq` block for better readability
- Simplified the object file generation rule to use a pattern rule instead of repeating the recipe for each object file
- Added quotes around `$@` and `$<` in recipe commands to handle filenames with spaces (maybe useful for Windows target)
- Added dependencies for the install target to ensure that the executable is built before it's copied to the destination directory

For the` constify.c` source file, I just removed the `\n\n` for the `PrintVersion` function.
