### PR TITLE
bin2txt: Remove extra new line when version is printed, optimize Makefile as well

### DIFF
--- a/tools/bin2txt/Makefile
+++ b/tools/bin2txt/Makefile
@@ -5,11 +5,10 @@ DATESTRING := $(shell date +%Y%m%d)
 # options for code generation
 #---------------------------------------------------------------------------------
 CC := gcc
-CFLAGS := -g -O2 -Wall -Wno-implicit-function-declaration -Wno-unused-result -D__BUILD_DATE="\"$(DATESTRING)\"" -D__BUILD_VERSION="\"$(VERSION)\"" -MMD
+CFLAGS := -g -O2 -Wall -Wno-implicit-function-declaration -Wno-unused-result -D__BUILD_DATE="\"$(DATESTRING)\"" -D__BUILD_VERSION="\"$(VERSION)\""
 
 SOURCES := bin2txt.c
 OBJS := $(SOURCES:%.c=%.o)
-DEPS := $(SOURCES:%.c=%.d)
 EXE := bin2txt
 DEFINES :=
 LIBS :=
@@ -25,8 +24,6 @@ endif
 #---------------------------------------------------------------------------------
 all: $(EXE)$(EXT)
 
--include $(DEPS)
-
 #---------------------------------------------------------------------------------
 $(EXE)$(EXT) : $(OBJS)
 	@echo "Linking $@"
@@ -38,7 +35,7 @@ $(EXE)$(EXT) : $(OBJS)
 
 #---------------------------------------------------------------------------------
 clean:
-	@rm -f $(DEPS) $(OBJS) $(EXE)$(EXT)
+	@rm -f $(OBJS) $(EXE)$(EXT)
 
 #---------------------------------------------------------------------------------
 install: all

--- a/tools/bin2txt/Makefile
+++ b/tools/bin2txt/Makefile
@@ -1,40 +1,46 @@
-VERSION = "1.0.0"
+VERSION := 1.0.0
+DATESTRING := $(shell date +%Y%m%d)
 
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------
-CC=gcc
-CFLAGS=-g -O2 -Wall -Wno-implicit-function-declaration -Wno-unused-result -D__BUILD_DATE="\"`date +'%Y%m%d'`\"" -D__BUILD_VERSION="\"$(VERSION)\""
+CC := gcc
+CFLAGS := -g -O2 -Wall -Wno-implicit-function-declaration -Wno-unused-result -D__BUILD_DATE="\"$(DATESTRING)\"" -D__BUILD_VERSION="\"$(VERSION)\"" -MMD
 
-SOURCES=bin2txt.c
-OBJS=bin2txt.o
-EXE=bin2txt
-DEFINES=
-LIBS=
+SOURCES := bin2txt.c
+OBJS := $(SOURCES:%.c=%.o)
+DEPS := $(SOURCES:%.c=%.d)
+EXE := bin2txt
+DEFINES :=
+LIBS :=
 
 ifeq ($(OS),Windows_NT)
-	EXT=.exe
+	EXT := .exe
 	CFLAGS += -D__HAS_STRUPR
 else
-	EXT=
+	EXT :=
 endif
 
 
 #---------------------------------------------------------------------------------
 all: $(EXE)$(EXT)
 
+-include $(DEPS)
+
 #---------------------------------------------------------------------------------
 $(EXE)$(EXT) : $(OBJS)
-	@echo make exe $(notdir $<)
+	@echo "Linking $@"
 	$(CC) $(CFLAGS) $(OBJS) -o $@
 
-bin2txt.o : bin2txt.c
-	@echo make obj $(notdir $<)
-	$(CC) $(CFLAGS) -c $<
+%.o : %.c
+	@echo "Compiling $<"
+	$(CC) $(CFLAGS) -c $< -o $@
 
 #---------------------------------------------------------------------------------
 clean:
-	rm -f *.tds $(EXE)$(EXT) $(OBJS)
+	@rm -f $(DEPS) $(OBJS) $(EXE)$(EXT)
 
-install:
-	cp $(EXE)$(EXT) ../../devkitsnes/tools/$(EXE)$(EXT)
+#---------------------------------------------------------------------------------
+install: all
+	$(MAKE) -C ../../devkitsnes/tools/
+	@cp $(EXE)$(EXT) ../../devkitsnes/tools/$(EXE)$(EXT)

--- a/tools/bin2txt/Makefile
+++ b/tools/bin2txt/Makefile
@@ -39,5 +39,4 @@ clean:
 
 #---------------------------------------------------------------------------------
 install: all
-	$(MAKE) -C ../../devkitsnes/tools/
 	@cp $(EXE)$(EXT) ../../devkitsnes/tools/$(EXE)$(EXT)

--- a/tools/bin2txt/bin2txt.c
+++ b/tools/bin2txt/bin2txt.c
@@ -24,8 +24,8 @@
 
 ---------------------------------------------------------------------------------*/
 
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #define BIN2TXTVERSION __BUILD_VERSION
@@ -33,7 +33,7 @@
 
 //// M A I N   V A R I A B L E S ////////////////////////////////////////////////
 int convformat = 1;      // conversion formation (1=c , 2 = asm)
-int quietmode = 0;       // 0 = not quiet, 1 = i can't say anything :P
+int quietmode  = 0;      // 0 = not quiet, 1 = i can't say anything :P
 FILE *fpi, *fpo;         // input and output file handler
 unsigned int filesize;   // input file size
 char filebase[256] = ""; // input filename
@@ -75,7 +75,7 @@ void PrintOptions(char *str)
 //////////////////////////////////////////////////////////////////////////////
 void PrintVersion(void)
 {
-    printf("\n\nbin2txt.exe (" BIN2TXTDATE ") version " BIN2TXTVERSION "");
+    printf("bin2txt.exe (" BIN2TXTDATE ") version " BIN2TXTVERSION "");
     printf("\nCopyright (c) 2012-2021 Alekmaul\n");
 }
 


### PR DESCRIPTION
Hi all,

 Some small improvements for `bin2txt`. I slighty optimized the `Makefile` and remove useless new lines in `bin2txt.c` when printing version.

Here the changes performed on the `Makefile`:

- Uses `:=` instead of `=` for variable assignment to prevent unnecessary re-evaluation.
- Uses `$(shell date +%Y%m%d)` instead of invoking the date command multiple times.
- Uses automatic variable expansion to reduce duplication in the `Makefile`.

For the` bin2txt.c` source file, I just removed the `\n\n` for the `PrintVersion` function and applied some formating (extra spaces, sort include ...).


