### PR TITLE
bin2txt: Remove extra new line when version is printed, optimize Makefile as well

### DIFF
--- a/tools/816-opt/Makefile
+++ b/tools/816-opt/Makefile
@@ -1,12 +1,12 @@
 CC = gcc
 CFLAGS = -Wall -Wextra -O2 -g
 
-BIN = 816-opt
+EXE = 816-opt
 SRC = src
 OBJ = build
 
 SOURCES := $(wildcard $(SRC)/*.c)
-OBJECTS := $(patsubst $(SRC)/%.c, $(OBJ)/%.o, $(SOURCES))
+OBJS := $(patsubst $(SRC)/%.c, $(OBJ)/%.o, $(SOURCES))
 
 ifeq ($(OS),Windows_NT)
 	EXT=.exe
@@ -14,19 +14,18 @@ else
 	EXT=
 endif
 
-all: $(BIN)$(EXT)
+all: $(EXE)$(EXT)
 
-$(BIN)$(EXT): $(OBJECTS)
+$(EXE)$(EXT): $(OBJS)
 	$(CC) $^ -o $@
 
 $(OBJ)/%.o: $(SRC)/%.c
 	$(CC) $(CFLAGS) -I$(SRC) -c $< -o $@
 
-install:
-	cp $(BIN)$(EXT) ../../devkitsnes/tools/$(BIN)$(EXT)
+install: $(EXE)$(EXT)
+	@cp $(EXE)$(EXT) ../../devkitsnes/tools/$(EXE)$(EXT)
 
 clean:
-	rm -rf ${OBJECTS}
-	rm -f $(BIN)$(EXT)
+	@rm -f ${OBJS} $(EXE)$(EXT)
 
-
+.PHONY: all clean install


### PR DESCRIPTION
Hi all,

 Some small improvements for `bin2txt`. I slighty optimized the `Makefile` and remove useless new lines in `bin2txt.c` when printing version.

Here the changes performed on the `Makefile`:

- Uses `:=` instead of `=` for variable assignment to prevent unnecessary re-evaluation.
- Uses `$(shell date +%Y%m%d)` instead of invoking the date command multiple times.
- Uses automatic variable expansion to reduce duplication in the `Makefile`.

For the` bin2txt.c` source file, I just removed the `\n\n` for the `PrintVersion` function and applied some formating (extra spaces, sort include ...).