### PR TITLE
Rollback to ucrt64, activate -j options to compile the compilers fast…

### DIFF
--- a/.github/workflows/pvsneslib_build_package.yml
+++ b/.github/workflows/pvsneslib_build_package.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - "develop"
-      - "custom"
 
       # ------------------------------------ #
       # Set O.S matrix                       #

--- a/.github/workflows/pvsneslib_build_package.yml
+++ b/.github/workflows/pvsneslib_build_package.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - "develop"
+      - "custom"
 
       # ------------------------------------ #
       # Set O.S matrix                       #
@@ -20,18 +21,18 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            name: ubuntu-latest
+            name: linux
           - os: windows-latest
-            name: windows-latest
+            name: windows
           - os: macos-latest
-            name: macos-latest
+            name: darwin
 
     steps:
       # ------------------------------------ #
       # Install dependencies                 #
       # ------------------------------------ #
       - name: Install dependencies for Linux
-        if: matrix.name == 'ubuntu-latest'
+        if: matrix.name == 'linux'
         run: |
           sudo apt update -y
           sudo apt-get install -y build-essential \
@@ -46,21 +47,20 @@ jobs:
               texlive-latex-extra
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 90
       - name: Install dependencies for Windows
-        if: matrix.name == 'windows-latest'
+        if: matrix.name == 'windows'
         uses: msys2/setup-msys2@v2
         with:
           update: true
-          msystem: MINGW64
+          msystem: UCRT64
           install: >-
-            mingw-w64-x86_64-toolchain
-            mingw-w64-x86_64-libsystre
-            mingw-w64-x86_64-cmake
+            mingw-w64-ucrt-x86_64-toolchain
+            mingw-w64-ucrt-x86_64-cmake
             base-devel
             git
             doxygen
             zip
       - name: Install dependencies for MacOS
-        if: matrix.name == 'macos-latest'
+        if: matrix.name == 'darwin'
         run: |
           brew update
           brew install doxygen
@@ -83,80 +83,57 @@ jobs:
           persist-credentials: false
 
       # ------------------------------------ #
-      # Compiling sources                    #
-      # ------------------------------------ #
-      # - name: Build PVSNESLIB for Linux
-      #   if: (matrix.name == 'ubuntu-latest')
-      #   run: |
-      #     cd pvsneslib
-      #     export PVSNESLIB_HOME=$(pwd)
-      #     make
-      # - name: Build PVSNESLIB for Windows
-      #   if: (matrix.name == 'windows-latest')
-      #   shell: msys2 {0}
-      #   run: |
-      #     cd pvsneslib
-      #     export PVSNESLIB_HOME=$(pwd)
-      #     make
-      # - name: Build PVSNESLIB for MacOS
-      #   if: (matrix.name == 'macos-latest')
-      #   run: |
-      #     cd pvsneslib
-      #     export PVSNESLIB_HOME=$(pwd)
-      #     PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
-      #     make
-
-      # ------------------------------------ #
       # Compiling sources and create release #
       # ------------------------------------ #
       - name: Build & Release PVSNESLIB for Linux
-        if: (matrix.name == 'ubuntu-latest')
+        if: (matrix.name == 'linux')
         run: |
           cd pvsneslib
           export PVSNESLIB_HOME=$(pwd)
-          make release
-          ldd devkitsnes/bin/* || true
-          ldd devkitsnes/tools/* || true
-          ls -rtl release/
+          make release | tee pvsneslib_release_${{ matrix.name }}.log
       - name: Build & Release PVSNESLIB for Windows
-        if: (matrix.name == 'windows-latest')
+        if: (matrix.name == 'windows')
         shell: msys2 {0}
         run: |
           cd pvsneslib
           export PVSNESLIB_HOME=$(pwd)
-          make release
-          ldd devkitsnes/bin/* || true
-          ldd devkitsnes/tools/* || true
-          ls -rtl release/
+          make release | tee pvsneslib_release_${{ matrix.name }}.log
       - name: Build & Release PVSNESLIB for MacOS
-        if: (matrix.name == 'macos-latest')
+        if: (matrix.name == 'darwin')
         run: |
           cd pvsneslib
           export PVSNESLIB_HOME=$(pwd)
-          PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
-          make release
-          otool -L devkitsnes/bin/* || true
-          otool -L devkitsnes/tools/* || true
-          ls -rtl release/
+          export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
+          make release | tee pvsneslib_release_${{ matrix.name }}.log
+
+      # ------------------------------------ #
+      # Checking libraries linking           #
+      # ------------------------------------ #
+      - name: Checking libraries linking PVSNESLIB toolchain
+        if: matrix.name == 'darwin'
+        run: |
+          cd pvsneslib
+          otool -L devkitsnes/bin/* devkitsnes/tools/* | tee pvsneslib_toolchain_linking_${{ matrix.name }}.log || true
+      - name: Checking libraries linking PVSNESLIB toolchain
+        if: matrix.name == 'windows' || matrix.name == 'linux'
+        run: |
+          cd pvsneslib
+          ldd devkitsnes/bin/* devkitsnes/tools/* | tee pvsneslib_toolchain_linking_${{ matrix.name }}.log || true
 
       # ------------------------------------ #
       # Upload releases                      #
       # ------------------------------------ #
-      - name: Upload PVSNESLIB release for Linux
-        if: (matrix.name == 'ubuntu-latest')
+      - name: Upload PVSNESLIB release
         uses: actions/upload-artifact@v3
         with:
-          name: pvsneslib_64b_linux.zip
-          path: pvsneslib/release/pvsneslib_64b_linux.zip
-      - name: Upload PVSNESLIB release for Windows
-        if: (matrix.name == 'windows-latest')
+          name: PVSNESLIB Release for ${{ matrix.name }}
+          path: pvsneslib/release/pvsneslib_64b_${{ matrix.name }}.zip
+
+      # ------------------------------------ #
+      # Upload releases                      #
+      # ------------------------------------ #
+      - name: Upload PVSNESLIB logs
         uses: actions/upload-artifact@v3
         with:
-          name: pvsneslib_64b_windows.zip
-          path: pvsneslib/release/pvsneslib_64b_windows.zip
-      - name: Upload PVSNESLIB release for MacOS
-        if: (matrix.name == 'macos-latest')
-        uses: actions/upload-artifact@v3
-        with:
-          name: pvsneslib_64b_darwin.zip
-          path: pvsneslib/release/pvsneslib_64b_darwin.zip
+          name: PVSNESLIB Release Logs for ${{ matrix.name }}
+          path: pvsneslib/*.log

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -10,25 +10,19 @@ TCC_DIR    := tcc-65816
 WLA_DIR    := wla-dx
 BIN_DIR    := ../devkitsnes/bin
 
-# Define variables for build options
-MAKE_OPTIONS := -j$(NUM_JOBS)
-
 # Define variables for System
 UNAME := $(shell uname -s)
 
 # Set default number of jobs to run in parallel based on available CPU cores
 ifeq ($(OS),Windows_NT)
   # Set NUM_JOBS to the number of processors on Windows
-  NUM_JOBS := $(NUMBER_OF_PROCESSORS)
+  MAKEFLAGS := -j$(NUMBER_OF_PROCESSORS)
 else ifeq ($(UNAME), Darwin)
   # Set NUM_JOBS to the number of CPUs on macOS
-  NUM_JOBS := $(shell sysctl -n hw.ncpu)
+  MAKEFLAGS := -j$(shell sysctl -n hw.ncpu)
 else ifeq ($(UNAME), Linux)
   # Set NUM_JOBS to the number of CPUs on Linux
-  NUM_JOBS := $(shell nproc)
-else
-  # Set NUM_JOBS to 1 for all other operating systems
-  NUM_JOBS := 1
+  MAKEFLAGS := -j$(shell nproc)
 endif
 
 # Declare the phony targets
@@ -49,7 +43,7 @@ tcc-configure:
 
 # Define the tcc target
 tcc:
-	$(MAKE) $(MAKE_OPTIONS) -C $(TCC_DIR)
+	$(MAKE) -C $(TCC_DIR)
 
 # Define the tcc-clean target
 tcc-clean:
@@ -61,11 +55,9 @@ tcc-install:
 
 # Define the wla target
 wla:
-	cd wla-dx ; \
-	cmake -G "$(CMAKE_TYPE)" . ; \
-	$(MAKE) wla-65816 ; \
-	$(MAKE) wla-spc700 ; \
-	$(MAKE) wlalink ; \
+	cd $(WLA_DIR) && \
+	cmake -G "$(CMAKE_TYPE)" . && \
+	$(MAKE) wla-65816 wla-spc700 wlalink
 
 # Define the wla-clean target
 wla-clean:


### PR DESCRIPTION
Hi all,

 Here the PR to back to ucrt64, update tcc to use a random token instead of tmpnam, and activate parallel compilation on compiler to make it faster. I tested on my laptop with Windows and Linux version, with runners, and docker containers.

 