### PR TITLE
Fix issue #224

### DIFF
--- a/.github/workflows/pvsneslib_build_package.yml
+++ b/.github/workflows/pvsneslib_build_package.yml
@@ -55,6 +55,7 @@ jobs:
             mingw-w64-ucrt-x86_64-toolchain
             mingw-w64-ucrt-x86_64-cmake
             mingw-w64-ucrt-x86_64-doxygen
+            mingw-w64-ucrt-x86_64-pcre2
             base-devel
             git
             zip

--- a/tools/816-opt/Makefile
+++ b/tools/816-opt/Makefile
@@ -12,7 +12,8 @@ ifeq ($(shell uname),Darwin)
     LDFLAGS := -pthread
 	EXT     :=
 else ifeq ($(OS),Windows_NT)
-	LDFLAGS += -lpthread -static -lregex -ltre -lintl -liconv
+	CFLAGS  += -DPCRE2_STATIC
+	LDFLAGS += -lpthread -static -lpcre2-posix -lpcre2-8 -liconv
 	EXT     :=.exe
 else
 	LDFLAGS += -lpthread -static

--- a/tools/816-opt/src/helpers.h
+++ b/tools/816-opt/src/helpers.h
@@ -2,10 +2,14 @@
 #define HELPERS_H
 
 #include <ctype.h>
-#include <regex.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef PCRE2_STATIC
+#include <pcre2posix.h>
+#else
+#include <regex.h>
+#endif
 
 /*!
  * @brief Max length of the line.


### PR DESCRIPTION
- add libpcre2 to the MSYS2 build workflow
- change 816-opt Makefile to use libpcre2 instead of libtre for regex on Windows
- change 816-opt/src/helpers.h to use PCRE2 header instead of regex.h (same API) on Windows

See also https://github.com/daniel-starke/pvsneslib/actions/runs/5684683944.
Reference: https://github.com/alekmaul/pvsneslib/issues/224