### PR TITLE
Tiled: Fix tmx2snes version check and update tmj files

### DIFF
--- a/snes-examples/games/likemario/map_1_1.tmj
+++ b/snes-examples/games/likemario/map_1_1.tmj
@@ -50,11 +50,11 @@
          "name":"Entities",
          "objects":[
                 {
-                 "class":"0",
                  "height":16,
                  "id":1,
                  "name":"Mario",
                  "rotation":0,
+                 "type":"0",
                  "visible":true,
                  "width":16,
                  "x":32,
@@ -70,7 +70,7 @@
  "nextobjectid":2,
  "orientation":"orthogonal",
  "renderorder":"right-down",
- "tiledversion":"1.9.2",
+ "tiledversion":"1.10.2",
  "tileheight":8,
  "tilesets":[
         {
@@ -1001,6 +1001,6 @@
         }],
  "tilewidth":8,
  "type":"map",
- "version":"1.9",
+ "version":"1.10",
  "width":300
 }

--- a/snes-examples/maps/mapscroll/tiledMario.tmj
+++ b/snes-examples/maps/mapscroll/tiledMario.tmj
@@ -59,7 +59,7 @@
  "nextobjectid":1,
  "orientation":"orthogonal",
  "renderorder":"right-down",
- "tiledversion":"1.9.2",
+ "tiledversion":"1.10.2",
  "tileheight":8,
  "tilesets":[
         {
@@ -1275,6 +1275,6 @@
         }],
  "tilewidth":8,
  "type":"map",
- "version":"1.9",
+ "version":"1.10",
  "width":422
 }

--- a/snes-examples/maps/tiled/Makefile
+++ b/snes-examples/maps/tiled/Makefile
@@ -19,7 +19,7 @@ tileslevel1.pic: tileslevel1.png
 	@echo convert map tileset ... $(notdir $@)
 	$(GFXCONV) -gs8 -pc16 -po48 -m -fpng -n $<
 
-BG1.m16: maplevel01.json tileslevel1.pic
+BG1.m16: maplevel01.tmj tileslevel1.pic
 	@echo convert map tiled ... $(notdir $@)
 	$(TMXCONV) $< tileslevel1.map
 

--- a/snes-examples/maps/tiled/maplevel01.tmj
+++ b/snes-examples/maps/tiled/maplevel01.tmj
@@ -59,7 +59,7 @@
  "nextobjectid":1,
  "orientation":"orthogonal",
  "renderorder":"right-down",
- "tiledversion":"1.9.2",
+ "tiledversion":"1.10.2",
  "tileheight":8,
  "tilesets":[
         {
@@ -6216,6 +6216,6 @@
         }],
  "tilewidth":8,
  "type":"map",
- "version":"1.9",
+ "version":"1.10",
  "width":224
 }

--- a/snes-examples/objects/mapandobjects/tiledMario.tmj
+++ b/snes-examples/objects/mapandobjects/tiledMario.tmj
@@ -50,7 +50,6 @@
          "name":"Entities",
          "objects":[
                 {
-                 "class":"1",
                  "height":16,
                  "id":1,
                  "name":"Goomba",
@@ -66,24 +65,24 @@
                          "value":"480"
                         }],
                  "rotation":0,
+                 "type":"1",
                  "visible":true,
                  "width":16,
                  "x":528,
                  "y":192
                 }, 
                 {
-                 "class":"0",
                  "height":16,
                  "id":2,
                  "name":"Mario",
                  "rotation":0,
+                 "type":"0",
                  "visible":true,
                  "width":16,
                  "x":15,
                  "y":96
                 }, 
                 {
-                 "class":"2",
                  "height":16,
                  "id":3,
                  "name":"koopatroopa",
@@ -99,13 +98,13 @@
                          "value":"640"
                         }],
                  "rotation":0,
+                 "type":"2",
                  "visible":true,
                  "width":16,
                  "x":680,
                  "y":192
                 }, 
                 {
-                 "class":"1",
                  "height":16,
                  "id":4,
                  "name":"Goomba",
@@ -121,13 +120,13 @@
                          "value":"768"
                         }],
                  "rotation":0,
+                 "type":"1",
                  "visible":true,
                  "width":16,
                  "x":866,
                  "y":191.333333333333
                 }, 
                 {
-                 "class":"2",
                  "height":16,
                  "id":5,
                  "name":"koopatroopa",
@@ -143,6 +142,7 @@
                          "value":"944"
                         }],
                  "rotation":0,
+                 "type":"2",
                  "visible":true,
                  "width":16,
                  "x":976,
@@ -158,7 +158,7 @@
  "nextobjectid":6,
  "orientation":"orthogonal",
  "renderorder":"right-down",
- "tiledversion":"1.9.2",
+ "tiledversion":"1.10.2",
  "tileheight":8,
  "tilesets":[
         {
@@ -1374,6 +1374,6 @@
         }],
  "tilewidth":8,
  "type":"map",
- "version":"1.9",
+ "version":"1.10",
  "width":422
 }

--- a/snes-examples/objects/nogravityobject/mapzelda.tmj
+++ b/snes-examples/objects/nogravityobject/mapzelda.tmj
@@ -64,11 +64,11 @@
          "name":"Entities",
          "objects":[
                 {
-                 "class":"0",
                  "height":16,
                  "id":1,
                  "name":"Link",
                  "rotation":0,
+                 "type":"0",
                  "visible":true,
                  "width":16,
                  "x":128,
@@ -84,7 +84,7 @@
  "nextobjectid":2,
  "orientation":"orthogonal",
  "renderorder":"right-down",
- "tiledversion":"1.9.2",
+ "tiledversion":"1.10.2",
  "tileheight":8,
  "tilesets":[
         {
@@ -1623,6 +1623,6 @@
         }],
  "tilewidth":8,
  "type":"map",
- "version":"1.9",
+ "version":"1.10",
  "width":128
 }

--- a/tools/tmx2snes/Makefile
+++ b/tools/tmx2snes/Makefile
@@ -1,5 +1,5 @@
 # Set version and date strings for the build
-VERSION    := 1.0.0
+VERSION    := 1.0.1
 DATESTRING := $(shell date +%Y%m%d)
 
 # Set the C compiler to use and the compiler flags

--- a/tools/tmx2snes/tmx2snes.c
+++ b/tools/tmx2snes/tmx2snes.c
@@ -48,7 +48,7 @@ typedef struct
 {
     int x;     // x coordinate in pixels.
     int y;     // y coordinate in pixels.
-    int class; // class of object (0=main character, 1..63 other classes)
+    int type; // type of object (0=main character, 1..63 other types)
     int minx;  // horizontal or vertical min x coordinate in pixels.
     int maxx;  // horizontal or vertical max x coordinate in pixels.
 } pvsneslib_object_t;
@@ -340,8 +340,8 @@ void WriteEntities(void)
     if (layer->object_count) {
         while (objm) {
             // put object in reverse order
-            objsnes[objidx].class = atoi(
-                objm->type.ptr); //(unsigned short) strtol(objm->class.ptr,&pend,10);
+            objsnes[objidx].type = atoi(
+                objm->type.ptr); //(unsigned short) strtol(objm->type.ptr,&pend,10);
             objsnes[objidx].x = (int) (objm->x);
             objsnes[objidx].y = (int) (objm->y);
             for (i = 0; i < objm->property_count; i++) {
@@ -370,7 +370,7 @@ void WriteEntities(void)
     for (i = 0; i < layer->object_count; i++) {
         PutWord(objsnes[i].x, fpo);
         PutWord(objsnes[i].y, fpo);
-        PutWord(objsnes[i].class, fpo);
+        PutWord(objsnes[i].type, fpo);
         PutWord(objsnes[i].minx, fpo);
         PutWord(objsnes[i].maxx, fpo);
     }


### PR DESCRIPTION
This change fixes the problem of tmx2snes when it tries to check if the version of the tmj file (tiled) is supported.

This error is due to the fact that we are trying to compare versions using floats.

Here the error:
`
convert map tiled ... map_1_1.m16
/home/kobenairb/workspace/tests/pvsneslib-last/devkitsnes/tools/tmx2snes map_1_1.tmj tiles.map
tmx2snes: Loading map: [map_1_1.tmj]
tmx2snes: error 'the export version you used (1.9) is not yet supported. The tool supports only the versions from 1.9 to 1.1.'
`

This change includes the patch in tmx2snes and the update of tmj files (tiled). I used the latest version of Tiled to do this. I also updated the tmx2snes version to 1.0.1.

I think this change requires a review, I'm not convinced of the relevance of my method to transform a float into 2 integers.

I might also be better off using #define to initialize supported versions rather than magic numbers:

`
    Version minExportSupportedVersion = {1, 9};
    Version maxExportSupportedVersion = {1, 10};
`

I tested the impacted roms, everything seems okay to me but a double or triple check would be preferable

My apologies for the formatting of tmx2snes.c which makes reviewing more complicated.