### PR TITLE
improve: rename logo roms name

### DIFF
--- a/snes-examples/logo/snes-logo-capcom/Makefile
+++ b/snes-examples/logo/snes-logo-capcom/Makefile
@@ -17,7 +17,7 @@ include ${PVSNESLIB_HOME}/devkitsnes/snes_rules
 
 #---------------------------------------------------------------------------------
 # ROMNAME is used in snes_rules file
-export ROMNAME := logo
+export ROMNAME := LogoCapcom
 
 # to build musics, define SMCONVFLAGS with parameters you want
 SMCONVFLAGS	:= -s -o $(SOUNDBANK) -V -b 5

--- a/snes-examples/logo/snes-logo-konami/Makefile
+++ b/snes-examples/logo/snes-logo-konami/Makefile
@@ -17,7 +17,7 @@ include ${PVSNESLIB_HOME}/devkitsnes/snes_rules
 
 #---------------------------------------------------------------------------------
 # ROMNAME is used in snes_rules file
-export ROMNAME := logo
+export ROMNAME := LogoKonami
 
 # to build musics, define SMCONVFLAGS with parameters you want
 SMCONVFLAGS	:= -s -o $(SOUNDBANK) -V -b 5

--- a/snes-examples/logo/snes-logo-pvsneslib/Makefile
+++ b/snes-examples/logo/snes-logo-pvsneslib/Makefile
@@ -17,7 +17,7 @@ include ${PVSNESLIB_HOME}/devkitsnes/snes_rules
 
 #---------------------------------------------------------------------------------
 # ROMNAME is used in snes_rules file
-export ROMNAME := logo
+export ROMNAME := LogoPVSnesLib
 
 # to build musics, define SMCONVFLAGS with parameters you want
 SMCONVFLAGS	:= -s -o $(SOUNDBANK) -V -b 5


### PR DESCRIPTION
# Description
Rename the logo roms name so they can correctly be copied in `snes-examples/bin` folder.

# Checklist
- [x] Built and Tested with PVSnesLib's develop branch - commit: 60b46d8e56aa1b1b35f2254ccb5b99042b492b3c 
- [x] Tested on Windows 10