### PR TITLE
Fix bug getPalette

### DIFF
--- a/pvsneslib/source/videos.asm
+++ b/pvsneslib/source/videos.asm
@@ -1069,7 +1069,6 @@ getPalette:
 
     sep #$20
     lda 8,s                             ; get paletteSize (6+2)
-    dea                                 ; to have 0..palette size
     tax
 
     lda 7,s                             ; get palette entry (5+2)
@@ -1081,7 +1080,9 @@ getPalette:
     and #$7F                            ; remove openbus read
     inc tcc__r0                         ; to go to msb
     sta [tcc__r0]
+    rep #$20                            ; 16bit if *paletteColors leaves 8bit page boundary 
     inc tcc__r0                         ; to go to next entry
+    sep #$20
     pla
     ina
     dex


### PR DESCRIPTION
-remove unnecessary "dea", the paletteSize parameter act now as the number of colors you want to get
-add rep $#20 before inc, that solves the page boundery issue, when an array in wram overlaps two pages