### PR TITLE
feat: deduplicate flipped tiles

### DIFF
--- a/tools/gfx4snes/readme.md
+++ b/tools/gfx4snes/readme.md
@@ -40,6 +40,7 @@ where filename is a 256 color PNG or BMP file
 - `-g` Include high priority bit in map
 - `-y` Generate map in pages of 32x32 blocks (good for scrolling)
 - `-R` No tile reduction (not advised)  
+- `-F` deduplicate flipped tiles  
 - `-M (1|5|6|7||9)` Convert the whole picture for mode 1, 5, 6 or 7 format, 9 is without map constraint [1]
   
 ### Palette options

--- a/tools/gfx4snes/src/gfx4snes.h
+++ b/tools/gfx4snes/src/gfx4snes.h
@@ -44,6 +44,7 @@ typedef struct
     int mapoutput;				    											// 1 = save the map
     int maphighpriority;                                                        // 1 = b13 of high priority on
     int map32pages;                                                             // 1 = tile map pages of 32x32 (for scrolling)
+    int tileflip;                                                               // 1 = consider H/V flips when reducing tiles ("tile-flip")
 
     int metasprite;                                                             // 1 = generate header files for metasprites
     int metawidth;                                                              // width of the metasprite

--- a/tools/gfx4snes/src/maps.c
+++ b/tools/gfx4snes/src/maps.c
@@ -34,8 +34,112 @@
 #include "maps.h"
 
 #include "common.h"
+#include <stdint.h>
 
 //-------------------------------------------------------------------------------------------------
+// hash and flip helpers
+// orientation-aware hash and equality helpers
+// orient: 0=orig, 1=H, 2=V, 3=HV
+static uint32_t tile_hash_orient(const unsigned char *tile, int w, int h, int orient)
+{
+    uint32_t hash = 0x811c9dc5u;
+    for (int r = 0; r < h; ++r) {
+        for (int c = 0; c < w; ++c) {
+            int srcc = c;
+            int srcr = r;
+            if (orient & 1) srcc = (w - 1) - c; // H bit
+            if (orient & 2) srcr = (h - 1) - r; // V bit
+            unsigned char v = tile[srcr * w + srcc];
+            hash ^= (uint32_t)v;
+            hash *= 0x01000193u;
+        }
+    }
+    return hash;
+}
+
+static int tile_equal_orient(const unsigned char *a, const unsigned char *b, int w, int h, int orient)
+{
+    for (int r = 0; r < h; ++r) {
+        for (int c = 0; c < w; ++c) {
+            int srcc = c;
+            int srcr = r;
+            if (orient & 1) srcc = (w - 1) - c; // H
+            if (orient & 2) srcr = (h - 1) - r; // V
+            if (a[r * w + c] != b[srcr * w + srcc]) return 0;
+        }
+    }
+    return 1;
+}
+
+// simple chained hash table for tile indices
+typedef struct {
+    uint32_t hash;
+    int tile_index;
+    int next;
+} hash_entry_t;
+
+typedef struct {
+    int size;       // number of buckets
+    int head_count; // number of entries used
+    int *heads;     // bucket heads
+    hash_entry_t *entries;
+    int max_entries;
+} hash_table_t;
+
+static hash_table_t *hash_table_create(int buckets, int max_entries)
+{
+    hash_table_t *ht = (hash_table_t *)malloc(sizeof(hash_table_t));
+    if (!ht) return NULL;
+    ht->size = buckets;
+    ht->max_entries = max_entries;
+    ht->head_count = 0;
+    ht->heads = (int *)malloc(sizeof(int) * buckets);
+    ht->entries = (hash_entry_t *)malloc(sizeof(hash_entry_t) * max_entries);
+    if (!ht->heads || !ht->entries) { free(ht->heads); free(ht->entries); free(ht); return NULL; }
+    for (int i = 0; i < buckets; ++i) ht->heads[i] = -1;
+    for (int i = 0; i < max_entries; ++i) ht->entries[i].next = -1;
+    return ht;
+}
+
+static void hash_table_free(hash_table_t *ht)
+{
+    if (!ht) return;
+    free(ht->heads);
+    free(ht->entries);
+    free(ht);
+}
+
+static void hash_table_insert(hash_table_t *ht, uint32_t hash, int tile_index)
+{
+    if (!ht) return;
+    if (ht->head_count >= ht->max_entries) return;
+    int bucket = (int)(hash % (uint32_t)ht->size);
+    int idx = ht->head_count++;
+    ht->entries[idx].hash = hash;
+    ht->entries[idx].tile_index = tile_index;
+    ht->entries[idx].next = ht->heads[bucket];
+    ht->heads[bucket] = idx;
+}
+
+// find a matching tile given hash and orient-aware equality check
+static int hash_table_find(hash_table_t *ht, uint32_t hash, const unsigned char *imgbuf, int cand_tile_offset, int cur_tile_offset, int w, int h, int orient)
+{
+    if (!ht) return -1;
+    int bucket = (int)(hash % (uint32_t)ht->size);
+    for (int e = ht->heads[bucket]; e != -1; e = ht->entries[e].next) {
+        if (ht->entries[e].hash != hash) continue;
+        int ti = ht->entries[e].tile_index;
+        const unsigned char *a = &imgbuf[ti * (w * h)];
+        const unsigned char *b = &imgbuf[cur_tile_offset * (w * h)];
+        if (orient == 0) {
+            if (memcmp(a, b, w * h) == 0) return ti;
+        } else {
+            if (tile_equal_orient(a, b, w, h, orient)) return ti;
+        }
+    }
+    return -1;
+}
+
 // imgbuf = image buffer
 // *nbtiles = number of tiles after map conversion
 // blksizex = size in pixels of image blocks width
@@ -49,7 +153,7 @@
 // istilereduction = 1 if we want tile reduction (i hope often ;) )
 // isblanktile = 1 if we want the 1st tile to be blank
 // isquiet = 0 if we want some messages in console
-unsigned short *map_convertsnes (unsigned char *imgbuf, int *nbtiles, int blksizex, int blksizey, int nbblockx, int nbblocky, int nbcolors, int offsetpal, int graphicmode, bool isnoreduction, bool isblanktile, bool is32size, bool isquiet)
+unsigned short *map_convertsnes (unsigned char *imgbuf, int *nbtiles, int blksizex, int blksizey, int nbblockx, int nbblocky, int nbcolors, int offsetpal, int graphicmode, bool isnoreduction, bool isblanktile, bool is32size, bool isflip, bool isquiet)
 {
     unsigned short *map;                                                            
     unsigned short tilevalue;
@@ -57,6 +161,10 @@ unsigned short *map_convertsnes (unsigned char *imgbuf, int *nbtiles, int blksiz
     unsigned char blanktile[128];
     unsigned int paletteno;
     unsigned int i, x, y;
+    // hash tables for flip-aware deduplication
+    hash_table_t *ht_orig = NULL, *ht_h = NULL, *ht_v = NULL, *ht_hv = NULL;
+    int ht_buckets = 0;
+    int ht_maxentries = 0;
 
     // if mode 5 or 6, reduce number of tiles in x
     if ((graphicmode==5) || (graphicmode==6)) 
@@ -87,6 +195,23 @@ unsigned short *map_convertsnes (unsigned char *imgbuf, int *nbtiles, int blksiz
 
     // add the palette number to tiles
     if (!isquiet) info("add palette entry #%d to tiles in map or metasprites...",offsetpal);
+    // prepare hash tables if flip-aware reduction requested
+    if (isflip) {
+        int total_tiles = nbblockx * nbblocky;
+        ht_buckets = total_tiles * 2 + 1;
+        ht_maxentries = total_tiles * 4 + 4;
+        ht_orig = hash_table_create(ht_buckets, ht_maxentries);
+        ht_h = hash_table_create(ht_buckets, ht_maxentries);
+        ht_v = hash_table_create(ht_buckets, ht_maxentries);
+        ht_hv = hash_table_create(ht_buckets, ht_maxentries);
+        if (!ht_orig || !ht_h || !ht_v || !ht_hv) {
+            // allocation failed -> disable flip handling
+            if (!isquiet) warning("tile-flip disabled due to memory allocation failure");
+            hash_table_free(ht_orig); hash_table_free(ht_h); hash_table_free(ht_v); hash_table_free(ht_hv);
+            ht_orig = ht_h = ht_v = ht_hv = NULL;
+            isflip = false;
+        }
+    }
     currenttile = 0;
     for (y = 0; y < nbblocky; y++)
     {
@@ -171,6 +296,24 @@ unsigned short *map_convertsnes (unsigned char *imgbuf, int *nbtiles, int blksiz
     // save the first tilemap piece
     map[0] += tilevalue;
 
+    // insert existing tiles (currently only tile 0) into hash tables
+    if (isflip && ht_orig) {
+        for (i = 0; i < newnbtiles; ++i) {
+            const unsigned char *t = &imgbuf[i * sizetile];
+            uint32_t h0 = tile_hash_orient(t, blksizex, blksizey, 0);
+            uint32_t hh = tile_hash_orient(t, blksizex, blksizey, 1);
+            uint32_t hvv = tile_hash_orient(t, blksizex, blksizey, 2);
+            uint32_t hhv = tile_hash_orient(t, blksizex, blksizey, 3);
+            hash_table_insert(ht_orig, h0, i);
+            hash_table_insert(ht_h, hh, i);
+            hash_table_insert(ht_v, hvv, i);
+            hash_table_insert(ht_hv, hhv, i);
+        }
+    }
+
+    // debug counters for flip detection
+    int cnt_orig = 0, cnt_h = 0, cnt_v = 0, cnt_hv = 0, cnt_new = 0;
+
     // add all the tiles to time map
     if (!isquiet) {
         if (isnoreduction) info("check whole bitmap (%dx%d blocks) for tile map with no optimization!...",nbblockx,nbblocky);
@@ -187,14 +330,63 @@ unsigned short *map_convertsnes (unsigned char *imgbuf, int *nbtiles, int blksiz
 
             // if no tile reduction
             if (isnoreduction)
-            {   
-                // always add a new tile
-                i = newnbtiles;
+            {
+                if (isflip && ht_orig) {
+                    const unsigned char *cur = &imgbuf[currenttile * sizetile];
+                    int found = -1;
+                    int flipmask = 0;
+                    uint32_t base_hash = tile_hash_orient(cur, blksizex, blksizey, 0);
+                    found = hash_table_find(ht_orig, base_hash, imgbuf, 0, currenttile, blksizex, blksizey, 0);
+                    if (found == -1) {
+                        found = hash_table_find(ht_h, base_hash, imgbuf, 0, currenttile, blksizex, blksizey, 1);
+                        if (found != -1) flipmask = 0x4000;
+                    }
+                    if (found == -1) {
+                        found = hash_table_find(ht_v, base_hash, imgbuf, 0, currenttile, blksizex, blksizey, 2);
+                        if (found != -1) flipmask = 0x8000;
+                    }
+                    if (found == -1) {
+                        found = hash_table_find(ht_hv, base_hash, imgbuf, 0, currenttile, blksizex, blksizey, 3);
+                        if (found != -1) flipmask = 0xC000;
+                    }
 
-                // yes -> add it
-                memcpy(&imgbuf[newnbtiles * sizetile], &imgbuf[currenttile * sizetile], sizetile);
-                tilevalue = newnbtiles + blanktileabsent;
-                newnbtiles++;
+                    if (found != -1) {
+                        tilevalue = found + blanktileabsent;
+                        tilevalue |= flipmask;
+                        if (!isquiet) {
+                            if (flipmask == 0) info("tile @ %d,%d uses canonical tile %d (orig)", x, y, found);
+                            else if (flipmask == 0x4000) info("tile @ %d,%d uses canonical tile %d (H)", x, y, found);
+                            else if (flipmask == 0x8000) info("tile @ %d,%d uses canonical tile %d (V)", x, y, found);
+                            else if (flipmask == 0xC000) info("tile @ %d,%d uses canonical tile %d (HV)", x, y, found);
+                        }
+                        if (flipmask == 0) cnt_orig++; else if (flipmask == 0x4000) cnt_h++; else if (flipmask == 0x8000) cnt_v++; else if (flipmask == 0xC000) cnt_hv++;
+                    } else {
+                        // add new tile
+                        i = newnbtiles;
+                        memcpy(&imgbuf[newnbtiles * sizetile], &imgbuf[currenttile * sizetile], sizetile);
+                        tilevalue = newnbtiles + blanktileabsent;
+                        // insert new canonical tile into all hash tables
+                        const unsigned char *t = &imgbuf[i * sizetile];
+                        uint32_t ih0 = tile_hash_orient(t, blksizex, blksizey, 0);
+                        uint32_t ihh = tile_hash_orient(t, blksizex, blksizey, 1);
+                        uint32_t ihv = tile_hash_orient(t, blksizex, blksizey, 2);
+                        uint32_t ihhv = tile_hash_orient(t, blksizex, blksizey, 3);
+                        hash_table_insert(ht_orig, ih0, i);
+                        hash_table_insert(ht_h, ihh, i);
+                        hash_table_insert(ht_v, ihv, i);
+                        hash_table_insert(ht_hv, ihhv, i);
+                        newnbtiles++;
+                        cnt_new++;
+                    }
+                } else {
+                    // always add a new tile
+                    i = newnbtiles;
+
+                    // yes -> add it
+                    memcpy(&imgbuf[newnbtiles * sizetile], &imgbuf[currenttile * sizetile], sizetile);
+                    tilevalue = newnbtiles + blanktileabsent;
+                    newnbtiles++;
+                }
             }
             else
             {
@@ -206,24 +398,73 @@ unsigned short *map_convertsnes (unsigned char *imgbuf, int *nbtiles, int blksiz
                 // check for matches with previous tiles if tile reduction on
                 else
                 {
-                    for (i = 0; i < newnbtiles; i++)
-                    {
-                        if (memcmp(&imgbuf[i * sizetile], &imgbuf[currenttile * sizetile], sizetile) == 0)
-                            break;
-                    }
+                    if (isflip && ht_orig) {
+                        const unsigned char *cur = &imgbuf[currenttile * sizetile];
+                        int found = -1;
+                        int flipmask = 0;
+                        uint32_t base_hash = tile_hash_orient(cur, blksizex, blksizey, 0);
+                        found = hash_table_find(ht_orig, base_hash, imgbuf, 0, currenttile, blksizex, blksizey, 0);
+                        if (found == -1) {
+                            found = hash_table_find(ht_h, base_hash, imgbuf, 0, currenttile, blksizex, blksizey, 1);
+                            if (found != -1) flipmask = 0x4000;
+                        }
+                        if (found == -1) {
+                            found = hash_table_find(ht_v, base_hash, imgbuf, 0, currenttile, blksizex, blksizey, 2);
+                            if (found != -1) flipmask = 0x8000;
+                        }
+                        if (found == -1) {
+                            found = hash_table_find(ht_hv, base_hash, imgbuf, 0, currenttile, blksizex, blksizey, 3);
+                            if (found != -1) flipmask = 0xC000;
+                        }
 
-                    // is it a new tile?
-                    if (i == newnbtiles)
-                    {
-                        // yes -> add it
-                        memcpy(&imgbuf[newnbtiles * sizetile], &imgbuf[currenttile * sizetile], sizetile);
-                        tilevalue = newnbtiles + blanktileabsent;
-                        newnbtiles++;
-                    }
-                    else
-                    { 
-                        // no -> find what tile number it is
-                        tilevalue = i + blanktileabsent;
+                        if (found != -1) {
+                            tilevalue = found + blanktileabsent;
+                            tilevalue |= flipmask;
+                            if (!isquiet) {
+                                if (flipmask == 0) info("tile @ %d,%d uses canonical tile %d (orig)", x, y, found);
+                                else if (flipmask == 0x4000) info("tile @ %d,%d uses canonical tile %d (H)", x, y, found);
+                                else if (flipmask == 0x8000) info("tile @ %d,%d uses canonical tile %d (V)", x, y, found);
+                                else if (flipmask == 0xC000) info("tile @ %d,%d uses canonical tile %d (HV)", x, y, found);
+                            }
+                            if (flipmask == 0) cnt_orig++; else if (flipmask == 0x4000) cnt_h++; else if (flipmask == 0x8000) cnt_v++; else if (flipmask == 0xC000) cnt_hv++;
+                        } else {
+                            // yes -> add it
+                            i = newnbtiles;
+                            memcpy(&imgbuf[newnbtiles * sizetile], &imgbuf[currenttile * sizetile], sizetile);
+                            tilevalue = newnbtiles + blanktileabsent;
+                            // insert new canonical tile into all hash tables
+                            const unsigned char *t = &imgbuf[i * sizetile];
+                            uint32_t ih0 = tile_hash_orient(t, blksizex, blksizey, 0);
+                            uint32_t ihh = tile_hash_orient(t, blksizex, blksizey, 1);
+                            uint32_t ihv = tile_hash_orient(t, blksizex, blksizey, 2);
+                            uint32_t ihhv = tile_hash_orient(t, blksizex, blksizey, 3);
+                            hash_table_insert(ht_orig, ih0, i);
+                            hash_table_insert(ht_h, ihh, i);
+                            hash_table_insert(ht_v, ihv, i);
+                            hash_table_insert(ht_hv, ihhv, i);
+                            newnbtiles++;
+                            cnt_new++;
+                        }
+                    } else {
+                        for (i = 0; i < newnbtiles; i++)
+                        {
+                            if (memcmp(&imgbuf[i * sizetile], &imgbuf[currenttile * sizetile], sizetile) == 0)
+                                break;
+                        }
+
+                        // is it a new tile?
+                        if (i == newnbtiles)
+                        {
+                            // yes -> add it
+                            memcpy(&imgbuf[newnbtiles * sizetile], &imgbuf[currenttile * sizetile], sizetile);
+                            tilevalue = newnbtiles + blanktileabsent;
+                            newnbtiles++;
+                        }
+                        else
+                        { 
+                            // no -> find what tile number it is
+                            tilevalue = i + blanktileabsent;
+                        }
                     }
                 }
             }
@@ -299,6 +540,17 @@ unsigned short *map_convertsnes (unsigned char *imgbuf, int *nbtiles, int blksiz
         else info("%d tiles processed",newnbtiles);
     }
     *nbtiles = ((graphicmode==5) || (graphicmode==6)) ? newnbtiles<<1 : newnbtiles;
+
+    // free hash tables
+    if (ht_orig) hash_table_free(ht_orig);
+    if (ht_h) hash_table_free(ht_h);
+    if (ht_v) hash_table_free(ht_v);
+    if (ht_hv) hash_table_free(ht_hv);
+
+    // summary of flip detection
+    if (isflip && !isquiet) {
+        info("tile-flip summary: orig=%d H=%d V=%d HV=%d new=%d", cnt_orig, cnt_h, cnt_v, cnt_hv, cnt_new);
+    }
 
     return map;
 } 

--- a/tools/gfx4snes/src/maps.h
+++ b/tools/gfx4snes/src/maps.h
@@ -4,7 +4,7 @@
 #include "errors.h"
 
 //-------------------------------------------------------------------------------------------------
-extern unsigned short *map_convertsnes (unsigned char *imgbuf, int *nbtiles, int blksizex, int blksizey, int nbblockx, int nbblocky, int nbcolors, int offsetpal, int graphicmode, bool isnoreduction, bool isblanktile, bool is32size, bool isquiet);
+extern unsigned short *map_convertsnes (unsigned char *imgbuf, int *nbtiles, int blksizex, int blksizey, int nbblockx, int nbblocky, int nbcolors, int offsetpal, int graphicmode, bool isnoreduction, bool isblanktile, bool is32size, bool isflip, bool isquiet);
 extern void map_save (const char *filename, unsigned short *map,int snesmode, int nbtilex, int nbtiley, int tileoffset,int priority, bool isquiet);
 
 #endif


### PR DESCRIPTION
This change de-duplicates tiles flipped along X, Y, and both X+Y axes, reducing redundant tile data in the tileset and saving VRAM. Flipped variants are recognized as duplicates, ensuring only one copy is stored.