### PR TITLE
snesmod: bound the SFX streaming handshake with a watchdog (fixes #226)

### DIFF
--- a/pvsneslib/source/snesmodwla.asm
+++ b/pvsneslib/source/snesmodwla.asm
@@ -70,6 +70,8 @@
 ; process for 5 scanlines
 .define PROCESS_TIME 5
 .define INIT_DATACOPY 13
+; loop1 watchdog timeout (~1/4 NTSC frame); loops 2/3 arm with stz
+.define SPC_WDOG_INIT 0FFFFh
 
 ;======================================================================
 ;zeropage
@@ -83,6 +85,7 @@ spc_bank:	DS 1
 
 spc1:		DS 2
 spc2:		DS 2
+spc_wdog:	DS 2	; SFX stream handshake watchdog
 
 spc_fread:	DS 1
 spc_fwrite:	DS 1
@@ -1077,8 +1080,13 @@ spcProcessStream:
 	ora	#128			;
 	sta	REG_APUIO0		;
 ;-----------------------------------------------------------------------
--:	bit	REG_APUIO0		; wait for SPC
-	bpl	-			;
+	ldx	#SPC_WDOG_INIT		; watchdog: X counts down (free here)
+-:	bit	REG_APUIO0		; wait for SPC to ack the stream
+	bmi	@stream_ready		;
+	dex				;
+	bne	-			;
+	jmp	@stream_abort		; SPC never answered -> recover
+@stream_ready:
 ;-----------------------------------------------------------------------
 	stz	REG_APUIO1		; if digi_init then:
 	lda	digi_init		;   clear digi_init
@@ -1136,8 +1144,13 @@ spcProcessStream:
 	sta	spc2
 	rep	#20h			; read 2 bytes
 	lda	[digi_src], y		;
+	stz	spc_wdog		; arm (0; first dec wraps to FFFF; keeps A)
 -:	cpx	REG_APUIO0		;-sync with spc
+	beq	@block_ready		;
+	dec	spc_wdog		;
 	bne	-			;
+	jmp	@stream_abort		; SPC stalled -> recover
+@block_ready:
 	inx				; increment v
 	sta	REG_APUIO2		; write 2 bytes
 	sep	#20h			;
@@ -1150,8 +1163,16 @@ spcProcessStream:
 	dec	spc1			; decrement block counter
 	bne	@next_block		;
 ;-----------------------------------------------------------------------
+	rep	#20h			; final wait, watchdogged
+	stz	spc_wdog		;
 -:	cpx	REG_APUIO0		; wait for spc
+	beq	@fin_ok		;
+	dec	spc_wdog		;
 	bne	-			;
+	jmp	@stream_abort		; SPC stalled -> recover
+@fin_ok:
+	sep	#20h			;
+@stream_restore:
 ;-----------------------------------------------------------------------:
 	lda	spc_pr+0		; restore port data
 	sta	REG_APUIO0		;
@@ -1172,7 +1193,12 @@ spcProcessStream:
 	sta	digi_src2		;
 	sep	#20h			;
 ;-----------------------------------------------------------------------
-	rts
+	rts				;
+;-----------------------------------------------------------------------
+@stream_abort:				; SPC did not respond: drop effect, recover
+	sep	#20h			;
+	stz	digi_active		; stop re-entry (digi_remain left; gated by active)
+	bra	@stream_restore		; share the port restore (digi_src fix-up is harmless)
 
 digi_rates:
 	.db	0, 3, 5, 7, 9, 11, 13


### PR DESCRIPTION
## Summary

Building with SFX can sporadically **freeze the whole program**. The freeze is
an infinite loop in the snesmod audio driver, reported in #226. This commit
makes the driver recover gracefully instead of hanging when the SPC700 stops
responding.

Fixes #226.

## Root cause

`spcProcessStream()` (`pvsneslib/source/snesmodwla.asm`) streams BRR data to the
SPC700 one block per frame, handing each block over the `REG_APUIO0..3` ports
with a counter handshake. It waits for the SPC700 in three spin loops:

```asm
-:  bit  REG_APUIO0      ; (1) wait for the SPC to ACK the STREAM request
    bpl  -
    ...
-:  cpx  REG_APUIO0      ; (2) per block: wait until the SPC echoes counter x
    bne  -
    ...
-:  cpx  REG_APUIO0      ; (3) wait for the final echo
    bne  -
```

All three are unbounded. If the 65816 and the SPC700 ever disagree about the
handshake state, each side waits for the other forever and the 65816 spins here
with interrupts effectively dead. The program hangs. The most reproducible
trigger is re-entering streaming while a stream is still in flight, so the freeze
is sporadic. The SPC700 firmware ships as a pre-assembled blob, so the recovery
has to live on the 65816 side.

The fix

Add a watchdog to each of the three wait loops. On timeout, control goes to a new
@stream_abort handler that stops re-entry (digi_active = 0) and falls
through to the existing port restore code before returning. The next
spcPlaySound() then starts the stream cleanly. A fatal freeze becomes, at
worst, a single dropped sound effect.

- Loop 1 (the STREAM ack bit wait): X is free here, so it's used directly
  as a 16-bit countdown (ldx #SPC_WDOG_INIT … dex/bne). No RAM, no mode
  switching.
- Loops 2 & 3 (the cpx sync waits): X is the live byte counter, so a
  2-byte direct page word spc_wdog is used. It's armed with stz spc_wdog
  (the first dec wraps 0 to 0xFFFF); stz doesn't touch A, so the live data
  word in A survives with no pha/pla. The loops already run in 16-bit M,
  so the dec needs no rep/sep.
- Abort does sep #20h / stz digi_active / bra @stream_restore, reusing
  the normal exit's port restore instead of duplicating it.

0xFFFF iterations is roughly 1/4 of an NTSC frame, hence, far longer than the
SPC700 ever legitimately needs to answer, yet short enough that recovery is
invisible.

Risk & size

- Healthy path is unchanged apart from the loop exit branch. The failure path
  degrades to a dropped effect while music keeps playing.
- spcProcessStream grows from 205 to 247 bytes (+42).
- spc_wdog lives in the existing zero page .RAMSECTION ".fp" next to spc1/spc2,
  reached with direct page addressing (D = 0, like every other driver variable).

Testing

- Assembles and links cleanly.
- No regression. Patched builds run for tens of thousands of frames firing the
  streamed SFX 100+ times, always advancing.
- Deterministic A/B with fault injection (an SPC that never ACKs a stream). The
  unpatched driver freezes. The patched driver recovers every time and keeps running.

Note (out of scope)

The same unbounded wait pattern exists in the boot/upload routines (spcBoot,
spcLoad, spcLoadEffect, spcAllocateSoundRegion). Those run once at init rather
than per frame and aren't subject to the streaming re-entry desync, hence, require
no fix.