### PR TITLE
Fix keyboard hotkeys typos in examples of README

### DIFF
--- a/snes-examples/graphics/Effects/TransparentWindow/README.md
+++ b/snes-examples/graphics/Effects/TransparentWindow/README.md
@@ -13,5 +13,5 @@ Code made by [Digifox](https://github.com/malayli).
 ### Visual Studio Code
 - Install Visual Studio Code
 - Open the root directory with Visual Studio Code
-- Build: Shit+Ctrl+B
+- Build: Ctrl + Shift + B
 - Open logo.sfc with a SNES Emulator

--- a/snes-examples/thirdparty/logo/snes-logo-capcom/README.md
+++ b/snes-examples/thirdparty/logo/snes-logo-capcom/README.md
@@ -13,5 +13,5 @@ Code made by [Digifox](https://github.com/malayli).
 ### Visual Studio Code
 - Install Visual Studio Code
 - Open the root directory with Visual Studio Code
-- Build: Shit+Ctrl+B
+- Build: Ctrl + Shift + B
 - Open logo.sfc with a SNES Emulator

--- a/snes-examples/thirdparty/logo/snes-logo-konami/README.md
+++ b/snes-examples/thirdparty/logo/snes-logo-konami/README.md
@@ -13,5 +13,5 @@ Code made by [Digifox](https://github.com/malayli).
 ### Visual Studio Code
 - Install Visual Studio Code
 - Open the root directory with Visual Studio Code
-- Build: Shit+Ctrl+B
+- Build: Ctrl + Shift + B
 - Open logo.sfc with a SNES Emulator

--- a/snes-examples/thirdparty/logo/snes-logo-pvsneslib/README.md
+++ b/snes-examples/thirdparty/logo/snes-logo-pvsneslib/README.md
@@ -14,5 +14,5 @@ Code made by [Digifox](https://github.com/malayli).
 ### Visual Studio Code
 - Install Visual Studio Code
 - Open the root directory with Visual Studio Code
-- Build: Shit+Ctrl+B
+- Build: Ctrl + Shift + B
 - Open logo.sfc with a SNES Emulator


### PR DESCRIPTION
I made it correction for build keyboard hotkey: Ctrl + Shift + B to run build task in Visual Studio Code.

Any question, review or feedbacks, please let me know. Thanks! :)

Best regards,
Martin Eesmaa